### PR TITLE
feat: event overlay (badges) for Month and Resources calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ function App() {
 | `eventHeight`               | `number`                                | No       | `26`    | Height of event items in pixels            |
 | `eventTextStyle`            | `(event: CalendarEvent) => TextStyle`   | No       | -       | Style function for event text              |
 | `eventEllipsizeMode`       | `'head' \| 'middle' \| 'tail' \| 'clip'` | No       | `'tail'` | Ellipsize mode for event text              |
+| `renderEventOverlay`       | `(event: CalendarEvent) => React.ReactNode` | No    | -       | Optional overlay above each event (use `position: 'absolute'` with `top` / `right` / `bottom` / `left`, or `MonthCalendarEventOverlay`) |
 | `bottomSpacing`            | `number`                                | No       | -       | Bottom spacing in pixels for scrollable content |
 
 ### MonthCalendarRef Methods

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -555,6 +555,33 @@ export default function App() {
     [monthEventBadgeCountById]
   );
 
+  const resourcesEventBadgeCountById = useMemo(() => {
+    return new Map<string, number>([
+      ['re-r1-a', 3],
+      ['re-r1-b', 8],
+      ['re-r2-b', 12],
+      ['re-r3-c', 99],
+    ]);
+  }, []);
+
+  const renderResourcesEventOverlay = useCallback(
+    (event: ResourcesCalendarEvent) => {
+      const count = resourcesEventBadgeCountById.get(event.id);
+      if (count == null || count <= 0) {
+        return null;
+      }
+      const label = count > 99 ? '99+' : String(count);
+      return (
+        <MonthCalendarEventOverlay position={{ top: -3, right: -3 }}>
+          <View style={styles.eventBadge}>
+            <Text style={styles.eventBadgeText}>{label}</Text>
+          </View>
+        </MonthCalendarEventOverlay>
+      );
+    },
+    [resourcesEventBadgeCountById]
+  );
+
   const handleScrollToTop = useCallback(() => {
     calendarRef.current?.scrollMonthViewToOffset(
       dayjs(date).format('YYYY-MM'),
@@ -852,6 +879,7 @@ export default function App() {
           bottomSpacing={200}
           eventTextStyle={(_event) => ({ fontSize: 12 })}
           eventEllipsizeMode={'clip'}
+          renderEventOverlay={renderResourcesEventOverlay}
           dateCellContainerStyle={(d) => {
             const commonStyle: ViewStyle = {};
             if (d.getDay() === 0 || d.getDay() === 6) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,6 +5,7 @@ import { type ViewStyle } from 'react-native';
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import {
   MonthCalendar,
+  MonthCalendarEventOverlay,
   ResourcesCalendar,
   type CalendarEvent,
   type ResourcesCalendarEvent,
@@ -525,6 +526,35 @@ export default function App() {
 
   const calendarRef = useRef<MonthCalendarRef>(null);
 
+  /** Demo: badge count per event id (month tab overlay) */
+  const monthEventBadgeCountById = useMemo(() => {
+    return new Map<string, number>([
+      ['1-2', 5],
+      ['2', 12],
+      ['3', 3],
+      ['4', 99],
+      ['5', 1],
+    ]);
+  }, []);
+
+  const renderMonthEventOverlay = useCallback(
+    (event: CalendarEvent) => {
+      const count = monthEventBadgeCountById.get(event.id);
+      if (count == null || count <= 0) {
+        return null;
+      }
+      const label = count > 99 ? '99+' : String(count);
+      return (
+        <MonthCalendarEventOverlay position={{ top: -4, right: -4 }}>
+          <View style={styles.eventBadge}>
+            <Text style={styles.eventBadgeText}>{label}</Text>
+          </View>
+        </MonthCalendarEventOverlay>
+      );
+    },
+    [monthEventBadgeCountById]
+  );
+
   const handleScrollToTop = useCallback(() => {
     calendarRef.current?.scrollMonthViewToOffset(
       dayjs(date).format('YYYY-MM'),
@@ -764,6 +794,7 @@ export default function App() {
           eventHeight={32}
           eventTextStyle={eventTextStyle}
           eventEllipsizeMode={'clip'}
+          renderEventOverlay={renderMonthEventOverlay}
           bottomSpacing={200}
         />
       ) : (
@@ -891,5 +922,19 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#333',
     fontWeight: '600',
+  },
+  eventBadge: {
+    minWidth: 18,
+    height: 18,
+    paddingHorizontal: 5,
+    borderRadius: 9,
+    backgroundColor: '#FF3B30',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  eventBadgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '700',
   },
 });

--- a/src/calendar/month-calendar/MonthCalendar.tsx
+++ b/src/calendar/month-calendar/MonthCalendar.tsx
@@ -5,7 +5,13 @@ import {
   type TextStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
-import { useState, useRef, useImperativeHandle, forwardRef } from 'react';
+import {
+  useState,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  type ReactNode,
+} from 'react';
 import type {
   CalendarEvent,
   WeekdayNum,
@@ -54,6 +60,7 @@ type MonthCalendarProps = {
   eventHeight?: number;
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   bottomSpacing?: number;
 };
 
@@ -173,6 +180,7 @@ export const MonthCalendar = forwardRef<MonthCalendarRef, MonthCalendarProps>(
               eventHeight={props.eventHeight}
               eventTextStyle={props.eventTextStyle}
               eventEllipsizeMode={props.eventEllipsizeMode}
+              renderEventOverlay={props.renderEventOverlay}
               bottomSpacing={props.bottomSpacing}
             />
           );

--- a/src/calendar/month-calendar/view/MonthCalendarEventOverlay.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarEventOverlay.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet, View, type ViewStyle } from 'react-native';
+import type { ReactNode } from 'react';
+
+export type MonthCalendarEventOverlayPosition = Pick<
+  ViewStyle,
+  'top' | 'bottom' | 'left' | 'right'
+>;
+
+type MonthCalendarEventOverlayProps = {
+  position: MonthCalendarEventOverlayPosition;
+  children: ReactNode;
+  style?: ViewStyle;
+  pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only';
+};
+
+/**
+ * Use inside MonthCalendar’s `renderEventOverlay` to place content over an event
+ * using top / right / bottom / left relative to the event row.
+ */
+export function MonthCalendarEventOverlay(
+  props: MonthCalendarEventOverlayProps
+) {
+  return (
+    <View
+      pointerEvents={props.pointerEvents ?? 'box-none'}
+      style={[styles.base, props.position, props.style]}
+    >
+      {props.children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    position: 'absolute',
+  },
+});

--- a/src/calendar/month-calendar/view/MonthCalendarViewItem.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarViewItem.tsx
@@ -27,6 +27,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
+  type ReactNode,
 } from 'react';
 import { MonthCalendarWeekDayRow } from './MonthCalendarWeekDayRow';
 
@@ -63,6 +64,7 @@ type MonthCalendarViewItemProps = {
   eventHeight?: number;
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   bottomSpacing?: number;
 };
 
@@ -228,6 +230,7 @@ export const MonthCalendarViewItem = forwardRef<
               eventHeight={props.eventHeight}
               eventTextStyle={props.eventTextStyle}
               eventEllipsizeMode={props.eventEllipsizeMode}
+              renderEventOverlay={props.renderEventOverlay}
               onLayout={(e) => {
                 weekHeights.current.set(weekId, e.nativeEvent.layout.height);
               }}

--- a/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import type { ReactNode } from 'react';
 import {
   StyleSheet,
   useWindowDimensions,
@@ -31,6 +32,7 @@ export const MonthCalendarWeekRow = (props: {
   eventHeight?: number;
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   onLayout?: (event: LayoutChangeEvent) => void;
 }) => {
   const eventHeight = props.eventHeight || 26;
@@ -175,50 +177,72 @@ export const MonthCalendarWeekRow = (props: {
                 });
               }
 
+              const eventOverlayNode = props.renderEventOverlay?.(event);
+              const showEventOverlay =
+                props.renderEventOverlay != null &&
+                eventOverlayNode != null &&
+                eventOverlayNode !== false;
+
               return (
-                <TouchableOpacity
+                <View
                   key={event.id}
                   style={[
-                    styles.event,
+                    styles.eventOuter,
                     {
-                      backgroundColor: event.backgroundColor,
-                      borderColor: event.borderColor,
-                      width: width,
+                      width,
                       height: eventHeight,
-                      ...(event.borderStyle !== undefined && {
-                        borderStyle: event.borderStyle,
-                      }),
-                      ...(event.borderWidth !== undefined && {
-                        borderWidth: event.borderWidth,
-                      }),
-                      ...(event.borderRadius !== undefined && {
-                        borderRadius: event.borderRadius,
-                      }),
                     },
                     isPrevDateEvent ? styles.prevDateEvent : {},
                     isLastRow ? styles.lastRowEvent : {},
                   ]}
-                  onPress={() => {
-                    props.onPressEvent?.(event);
-                  }}
-                  onLongPress={() => {
-                    props.onLongPressEvent?.(event);
-                  }}
-                  delayLongPress={props.delayLongPressEvent}
                 >
-                  <Text
-                    numberOfLines={1}
-                    ellipsizeMode={props.eventEllipsizeMode ?? 'tail'}
+                  <TouchableOpacity
                     style={[
-                      styles.eventTitle,
-                      { color: event.color },
-                      props.eventTextStyle?.(event),
+                      styles.event,
+                      {
+                        backgroundColor: event.backgroundColor,
+                        borderColor: event.borderColor,
+                        ...(event.borderStyle !== undefined && {
+                          borderStyle: event.borderStyle,
+                        }),
+                        ...(event.borderWidth !== undefined && {
+                          borderWidth: event.borderWidth,
+                        }),
+                        ...(event.borderRadius !== undefined && {
+                          borderRadius: event.borderRadius,
+                        }),
+                      },
                     ]}
-                    allowFontScaling={props.allowFontScaling}
+                    onPress={() => {
+                      props.onPressEvent?.(event);
+                    }}
+                    onLongPress={() => {
+                      props.onLongPressEvent?.(event);
+                    }}
+                    delayLongPress={props.delayLongPressEvent}
                   >
-                    {event.title}
-                  </Text>
-                </TouchableOpacity>
+                    <Text
+                      numberOfLines={1}
+                      ellipsizeMode={props.eventEllipsizeMode ?? 'tail'}
+                      style={[
+                        styles.eventTitle,
+                        { color: event.color },
+                        props.eventTextStyle?.(event),
+                      ]}
+                      allowFontScaling={props.allowFontScaling}
+                    >
+                      {event.title}
+                    </Text>
+                  </TouchableOpacity>
+                  {showEventOverlay ? (
+                    <View
+                      style={styles.eventOverlayHost}
+                      pointerEvents="box-none"
+                    >
+                      {eventOverlayNode}
+                    </View>
+                  ) : null}
+                </View>
               );
             })}
           </TouchableOpacity>
@@ -259,15 +283,25 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 14,
   },
+  eventOuter: {
+    position: 'relative',
+    marginTop: EVENT_GAP,
+    marginLeft: EVENT_GAP,
+  },
   event: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
     borderWidth: 0.5,
     borderRadius: 4,
     paddingHorizontal: 4,
     flexDirection: 'row',
     alignItems: 'center',
     boxShadow: '0 0 2px 0 rgba(0, 0, 0, 0.1)',
-    marginTop: EVENT_GAP,
-    marginLeft: EVENT_GAP,
+  },
+  eventOverlayHost: {
+    ...StyleSheet.absoluteFillObject,
+    pointerEvents: 'box-none',
   },
   prevDateEvent: {
     marginLeft: -1,

--- a/src/calendar/resources-calendar/ResourcesCalendar.tsx
+++ b/src/calendar/resources-calendar/ResourcesCalendar.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import type {
   CalendarEvent,
   CalendarResource,
@@ -43,6 +49,7 @@ type ResourcesCalendarProps = {
   bottomSpacing?: number;
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   dateCellContainerStyle?: (date: Date) => ViewStyle;
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
   hiddenMonth?: boolean;
@@ -69,6 +76,7 @@ type ResourceRowProps = {
   eventHeight: number;
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
   allowFontScaling?: boolean;
   onLayout?: (height: number) => void;
@@ -92,6 +100,7 @@ function ResourceRow({
   eventHeight,
   eventTextStyle,
   eventEllipsizeMode,
+  renderEventOverlay,
   cellContainerStyle,
   allowFontScaling,
   onLayout,
@@ -227,46 +236,65 @@ function ResourceRow({
                   rowNum: rowIndex + 1,
                 });
 
+                const eventOverlayNode = renderEventOverlay?.(event);
+                const showEventOverlay =
+                  renderEventOverlay != null &&
+                  eventOverlayNode != null &&
+                  eventOverlayNode !== false;
+
                 return (
-                  <TouchableOpacity
-                    data-component-name="resources-calendar-event"
+                  <View
                     key={event.id}
                     style={[
-                      styles.event,
-                      {
-                        backgroundColor: event.backgroundColor,
-                        borderColor: event.borderColor,
-                        width,
-                        height: eventHeight,
-                        ...(event.borderStyle !== undefined && {
-                          borderStyle: event.borderStyle,
-                        }),
-                        ...(event.borderWidth !== undefined && {
-                          borderWidth: event.borderWidth,
-                        }),
-                        ...(event.borderRadius !== undefined && {
-                          borderRadius: event.borderRadius,
-                        }),
-                      },
+                      styles.eventOuter,
+                      { width, height: eventHeight },
                       isPrevDateEvent ? styles.prevDateEvent : {},
                     ]}
-                    onPress={() => onPressEvent?.(event)}
-                    onLongPress={() => onLongPressEvent?.(event)}
-                    delayLongPress={delayLongPressEvent}
                   >
-                    <Text
-                      numberOfLines={1}
-                      ellipsizeMode={eventEllipsizeMode ?? 'tail'}
-                      allowFontScaling={allowFontScaling}
+                    <TouchableOpacity
+                      data-component-name="resources-calendar-event"
                       style={[
-                        styles.eventTitle,
-                        { color: event.color },
-                        eventTextStyle?.(event),
+                        styles.event,
+                        {
+                          backgroundColor: event.backgroundColor,
+                          borderColor: event.borderColor,
+                          ...(event.borderStyle !== undefined && {
+                            borderStyle: event.borderStyle,
+                          }),
+                          ...(event.borderWidth !== undefined && {
+                            borderWidth: event.borderWidth,
+                          }),
+                          ...(event.borderRadius !== undefined && {
+                            borderRadius: event.borderRadius,
+                          }),
+                        },
                       ]}
+                      onPress={() => onPressEvent?.(event)}
+                      onLongPress={() => onLongPressEvent?.(event)}
+                      delayLongPress={delayLongPressEvent}
                     >
-                      {event.title}
-                    </Text>
-                  </TouchableOpacity>
+                      <Text
+                        numberOfLines={1}
+                        ellipsizeMode={eventEllipsizeMode ?? 'tail'}
+                        allowFontScaling={allowFontScaling}
+                        style={[
+                          styles.eventTitle,
+                          { color: event.color },
+                          eventTextStyle?.(event),
+                        ]}
+                      >
+                        {event.title}
+                      </Text>
+                    </TouchableOpacity>
+                    {showEventOverlay ? (
+                      <View
+                        style={styles.eventOverlayHost}
+                        pointerEvents="box-none"
+                      >
+                        {eventOverlayNode}
+                      </View>
+                    ) : null}
+                  </View>
                 );
               })}
             </TouchableOpacity>
@@ -421,6 +449,7 @@ export function ResourcesCalendar(props: ResourcesCalendarProps) {
     eventHeight: props.eventHeight ?? DEFAULT_EVENT_HEIGHT,
     eventTextStyle: props.eventTextStyle,
     eventEllipsizeMode: props.eventEllipsizeMode,
+    renderEventOverlay: props.renderEventOverlay,
     cellContainerStyle: props.cellContainerStyle,
     allowFontScaling: props.allowFontScaling,
     inlineBand: isInlineBand
@@ -739,14 +768,24 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: 'black',
   },
+  eventOuter: {
+    position: 'relative',
+    marginTop: EVENT_GAP,
+    marginLeft: EVENT_GAP,
+  },
   event: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
     borderWidth: 0.5,
     borderRadius: 4,
     paddingHorizontal: 4,
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: EVENT_GAP,
-    marginLeft: EVENT_GAP,
+  },
+  eventOverlayHost: {
+    ...StyleSheet.absoluteFillObject,
+    pointerEvents: 'box-none',
   },
   prevDateEvent: {
     marginLeft: -1,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 export { MonthCalendar } from './calendar/month-calendar/MonthCalendar';
+export { MonthCalendarEventOverlay } from './calendar/month-calendar/view/MonthCalendarEventOverlay';
 export type { CalendarEvent } from './types/month-calendar';
 export type { MonthCalendarRef } from './calendar/month-calendar/MonthCalendar';
+export type { MonthCalendarEventOverlayPosition } from './calendar/month-calendar/view/MonthCalendarEventOverlay';
 
 export { ResourcesCalendar } from './calendar/resources-calendar/ResourcesCalendar';
 export type {


### PR DESCRIPTION
## Summary

Adds optional **per-event overlays** so consumers can render arbitrary UI (e.g. iOS-style notification badges) on top of calendar events, positioned with `top` / `right` / `bottom` / `left` relative to each event pill.

## Month calendar

- New prop: `renderEventOverlay?: (event: CalendarEvent) => React.ReactNode`
- Each event is wrapped in a `position: 'relative'` container; the touchable body fills it; overlays render in an `absoluteFill` host with `pointerEvents="box-none"` so taps pass through empty overlay space to the event.
- New exports: `MonthCalendarEventOverlay` helper and `MonthCalendarEventOverlayPosition` type.
- README: documents `renderEventOverlay`.

## Resources calendar

- Same API: `renderEventOverlay?: (event: CalendarEvent) => React.ReactNode` with the same layout behavior as the month view.

## Example app

- Month tab: demo red circular badges on selected event IDs.
- Resources tabs: demo badges on selected `re-*` event IDs.

## Commits

- `feat(month-calendar): add renderEventOverlay for absolute overlays on events`
- `feat(resources-calendar): add renderEventOverlay for event badges`

Made with [Cursor](https://cursor.com)