### PR TITLE
feat: prioritizeCellInteraction for Month and Resources calendars

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -19,10 +19,8 @@ type TabType = 'month' | 'resources-fixed-column' | 'resources-inline-band';
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabType>('month');
-  const [
-    prioritizeResourcesCellInteraction,
-    setPrioritizeResourcesCellInteraction,
-  ] = useState(false);
+  const [prioritizeCellInteraction, setPrioritizeCellInteraction] =
+    useState(false);
   const [date, setDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
@@ -795,17 +793,15 @@ export default function App() {
         </TouchableOpacity>
       </View>
 
-      {activeTab !== 'month' ? (
-        <View style={styles.resourcesOptionRow}>
-          <Text style={styles.resourcesOptionLabel}>
-            セルタップ優先（イベントの上でもセル反応）
-          </Text>
-          <Switch
-            value={prioritizeResourcesCellInteraction}
-            onValueChange={setPrioritizeResourcesCellInteraction}
-          />
-        </View>
-      ) : null}
+      <View style={styles.resourcesOptionRow}>
+        <Text style={styles.resourcesOptionLabel}>
+          セルタップ優先（イベントの上でもセル反応）
+        </Text>
+        <Switch
+          value={prioritizeCellInteraction}
+          onValueChange={setPrioritizeCellInteraction}
+        />
+      </View>
 
       {/* Content */}
       {activeTab === 'month' ? (
@@ -839,6 +835,7 @@ export default function App() {
           eventEllipsizeMode={'clip'}
           renderEventOverlay={renderMonthEventOverlay}
           bottomSpacing={200}
+          prioritizeCellInteraction={prioritizeCellInteraction}
         />
       ) : (
         <ResourcesCalendar
@@ -918,7 +915,7 @@ export default function App() {
               }),
             };
           }}
-          prioritizeCellInteraction={prioritizeResourcesCellInteraction}
+          prioritizeCellInteraction={prioritizeCellInteraction}
         />
       )}
     </View>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -795,7 +795,7 @@ export default function App() {
 
       <View style={styles.resourcesOptionRow}>
         <Text style={styles.resourcesOptionLabel}>
-          セルタップ優先（イベントの上でもセル反応）
+          Prioritize cell taps (cells receive presses on top of events)
         </Text>
         <Switch
           value={prioritizeCellInteraction}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import ja from 'dayjs/locale/ja';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { type ViewStyle } from 'react-native';
-import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Text, Switch } from 'react-native';
 import {
   MonthCalendar,
   MonthCalendarEventOverlay,
@@ -19,6 +19,10 @@ type TabType = 'month' | 'resources-fixed-column' | 'resources-inline-band';
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabType>('month');
+  const [
+    prioritizeResourcesCellInteraction,
+    setPrioritizeResourcesCellInteraction,
+  ] = useState(false);
   const [date, setDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
@@ -791,6 +795,18 @@ export default function App() {
         </TouchableOpacity>
       </View>
 
+      {activeTab !== 'month' ? (
+        <View style={styles.resourcesOptionRow}>
+          <Text style={styles.resourcesOptionLabel}>
+            セルタップ優先（イベントの上でもセル反応）
+          </Text>
+          <Switch
+            value={prioritizeResourcesCellInteraction}
+            onValueChange={setPrioritizeResourcesCellInteraction}
+          />
+        </View>
+      ) : null}
+
       {/* Content */}
       {activeTab === 'month' ? (
         <MonthCalendar
@@ -902,6 +918,7 @@ export default function App() {
               }),
             };
           }}
+          prioritizeCellInteraction={prioritizeResourcesCellInteraction}
         />
       )}
     </View>
@@ -913,6 +930,22 @@ const styles = StyleSheet.create({
     flex: 1,
     marginTop: 60,
     width: '100%',
+  },
+  resourcesOptionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ddd',
+    backgroundColor: '#fafafa',
+  },
+  resourcesOptionLabel: {
+    flex: 1,
+    fontSize: 13,
+    color: '#333',
+    marginRight: 8,
   },
   tabBar: {
     flexDirection: 'row',

--- a/src/calendar/month-calendar/MonthCalendar.tsx
+++ b/src/calendar/month-calendar/MonthCalendar.tsx
@@ -62,6 +62,12 @@ type MonthCalendarProps = {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   bottomSpacing?: number;
+  /**
+   * When true, a transparent layer is placed above events in each day cell so
+   * `onPressCell` / `onLongPressCell` receive touches for the full cell area.
+   * Event taps are disabled while this is on (overlay captures the gesture).
+   */
+  prioritizeCellInteraction?: boolean;
 };
 
 export const MonthCalendar = forwardRef<MonthCalendarRef, MonthCalendarProps>(
@@ -182,6 +188,7 @@ export const MonthCalendar = forwardRef<MonthCalendarRef, MonthCalendarProps>(
               eventEllipsizeMode={props.eventEllipsizeMode}
               renderEventOverlay={props.renderEventOverlay}
               bottomSpacing={props.bottomSpacing}
+              prioritizeCellInteraction={props.prioritizeCellInteraction}
             />
           );
         }}

--- a/src/calendar/month-calendar/view/MonthCalendarViewItem.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarViewItem.tsx
@@ -66,6 +66,7 @@ type MonthCalendarViewItemProps = {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   bottomSpacing?: number;
+  prioritizeCellInteraction?: boolean;
 };
 
 export const MonthCalendarViewItem = forwardRef<
@@ -231,6 +232,7 @@ export const MonthCalendarViewItem = forwardRef<
               eventTextStyle={props.eventTextStyle}
               eventEllipsizeMode={props.eventEllipsizeMode}
               renderEventOverlay={props.renderEventOverlay}
+              prioritizeCellInteraction={props.prioritizeCellInteraction}
               onLayout={(e) => {
                 weekHeights.current.set(weekId, e.nativeEvent.layout.height);
               }}

--- a/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
@@ -34,6 +34,7 @@ export const MonthCalendarWeekRow = (props: {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   onLayout?: (event: LayoutChangeEvent) => void;
+  prioritizeCellInteraction?: boolean;
 }) => {
   const eventHeight = props.eventHeight || 26;
   const { width: screenWidth } = useWindowDimensions();
@@ -74,7 +75,7 @@ export const MonthCalendarWeekRow = (props: {
             return dayjs(a.start).diff(dayjs(b.start));
           });
 
-        const events: (CalendarEvent | number)[] = [];
+        const cellEvents: (CalendarEvent | number)[] = [];
         if (weekId && props.eventPosition) {
           const rowNums = props.eventPosition.getRowNums({
             weekId,
@@ -84,33 +85,141 @@ export const MonthCalendarWeekRow = (props: {
           let eventIndex = 0;
           for (let ii = 1; ii <= rowsLength; ii++) {
             if (rowNums.includes(ii)) {
-              events.push(ii);
+              cellEvents.push(ii);
             } else {
               const event = filteredEvents[eventIndex];
               if (event) {
-                events.push(event);
+                cellEvents.push(event);
               }
               eventIndex++;
             }
           }
         }
-        return (
-          <TouchableOpacity
-            key={djs.get('date')}
-            style={[
-              styles.dayCellCountainer,
-              { minHeight: props.weekRowMinHeight },
-              { zIndex: 7 - dateIndex },
-              { borderColor: props.cellBorderColor ?? 'lightslategrey' },
-            ]}
-            onPress={() => {
-              props.onPressCell?.(djs.toDate());
-            }}
-            onLongPress={() => {
-              props.onLongPressCell?.(djs.toDate());
-            }}
-            delayLongPress={props.delayLongPressCell}
-          >
+
+        const showPrioritizedCellOverlay =
+          props.prioritizeCellInteraction === true &&
+          (props.onPressCell != null || props.onLongPressCell != null);
+
+        const cellWrapperStyle = [
+          styles.dayCellCountainer,
+          { minHeight: props.weekRowMinHeight },
+          { zIndex: 7 - dateIndex },
+          { borderColor: props.cellBorderColor ?? 'lightslategrey' },
+        ];
+
+        const eventRows = cellEvents.map((event, rowIndex) => {
+          if (typeof event === 'number') {
+            return (
+              <View
+                key={`spacer-${rowIndex}`}
+                style={{ height: eventHeight, marginBottom: EVENT_GAP }}
+              />
+            );
+          }
+
+          const rawStartDjs = dayjs(event.start);
+          const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
+          const endDjs = dayjs(event.end);
+          const isEndOnDayBoundary =
+            endDjs.hour() === 0 &&
+            endDjs.minute() === 0 &&
+            endDjs.second() === 0 &&
+            endDjs.millisecond() === 0;
+          const diffDays = Math.max(
+            0,
+            endDjs.startOf('day').diff(startDjs.startOf('day'), 'day') -
+              (isEndOnDayBoundary ? 1 : 0)
+          );
+
+          const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(djs);
+          let width =
+            (diffDays + 1) * dateColumnWidth -
+            EVENT_GAP * 2 -
+            CELL_BORDER_WIDTH * 2;
+
+          if (isPrevDateEvent) {
+            width += EVENT_GAP + 1;
+          }
+
+          const isLastRow = rowIndex === cellEvents.length - 1;
+
+          if (props.eventPosition && weekId) {
+            props.eventPosition.push({
+              weekId,
+              startDate: startDjs.toDate(),
+              days: diffDays + 1,
+              rowNum: rowIndex + 1,
+            });
+          }
+
+          const eventOverlayNode = props.renderEventOverlay?.(event);
+          const showEventOverlay =
+            props.renderEventOverlay != null &&
+            eventOverlayNode != null &&
+            eventOverlayNode !== false;
+
+          return (
+            <View
+              key={event.id}
+              style={[
+                styles.eventOuter,
+                {
+                  width,
+                  height: eventHeight,
+                },
+                isPrevDateEvent ? styles.prevDateEvent : {},
+                isLastRow ? styles.lastRowEvent : {},
+              ]}
+            >
+              <TouchableOpacity
+                style={[
+                  styles.event,
+                  {
+                    backgroundColor: event.backgroundColor,
+                    borderColor: event.borderColor,
+                    ...(event.borderStyle !== undefined && {
+                      borderStyle: event.borderStyle,
+                    }),
+                    ...(event.borderWidth !== undefined && {
+                      borderWidth: event.borderWidth,
+                    }),
+                    ...(event.borderRadius !== undefined && {
+                      borderRadius: event.borderRadius,
+                    }),
+                  },
+                ]}
+                onPress={() => {
+                  props.onPressEvent?.(event);
+                }}
+                onLongPress={() => {
+                  props.onLongPressEvent?.(event);
+                }}
+                delayLongPress={props.delayLongPressEvent}
+              >
+                <Text
+                  numberOfLines={1}
+                  ellipsizeMode={props.eventEllipsizeMode ?? 'tail'}
+                  style={[
+                    styles.eventTitle,
+                    { color: event.color },
+                    props.eventTextStyle?.(event),
+                  ]}
+                  allowFontScaling={props.allowFontScaling}
+                >
+                  {event.title}
+                </Text>
+              </TouchableOpacity>
+              {showEventOverlay ? (
+                <View style={styles.eventOverlayHost} pointerEvents="box-none">
+                  {eventOverlayNode}
+                </View>
+              ) : null}
+            </View>
+          );
+        });
+
+        const cellInner = (
+          <>
             <View
               style={[
                 styles.dayCellInner,
@@ -131,120 +240,39 @@ export const MonthCalendarWeekRow = (props: {
                 {text}
               </Text>
             </View>
-            {events.map((event, rowIndex) => {
-              if (typeof event === 'number') {
-                return (
-                  <View
-                    key={event}
-                    style={{ height: eventHeight, marginBottom: EVENT_GAP }}
-                  />
-                );
-              }
+            {eventRows}
+          </>
+        );
 
-              const rawStartDjs = dayjs(event.start);
-              const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
-              const endDjs = dayjs(event.end);
-              const isEndOnDayBoundary =
-                endDjs.hour() === 0 &&
-                endDjs.minute() === 0 &&
-                endDjs.second() === 0 &&
-                endDjs.millisecond() === 0;
-              const diffDays = Math.max(
-                0,
-                endDjs.startOf('day').diff(startDjs.startOf('day'), 'day') -
-                  (isEndOnDayBoundary ? 1 : 0)
-              );
-
-              const isPrevDateEvent =
-                dateIndex === 0 && rawStartDjs.isBefore(djs);
-              let width =
-                (diffDays + 1) * dateColumnWidth -
-                EVENT_GAP * 2 -
-                CELL_BORDER_WIDTH * 2;
-
-              if (isPrevDateEvent) {
-                width += EVENT_GAP + 1;
-              }
-
-              const isLastRow = rowIndex === events.length - 1;
-
-              if (props.eventPosition && weekId) {
-                props.eventPosition.push({
-                  weekId,
-                  startDate: startDjs.toDate(),
-                  days: diffDays + 1,
-                  rowNum: rowIndex + 1,
-                });
-              }
-
-              const eventOverlayNode = props.renderEventOverlay?.(event);
-              const showEventOverlay =
-                props.renderEventOverlay != null &&
-                eventOverlayNode != null &&
-                eventOverlayNode !== false;
-
-              return (
-                <View
-                  key={event.id}
-                  style={[
-                    styles.eventOuter,
-                    {
-                      width,
-                      height: eventHeight,
-                    },
-                    isPrevDateEvent ? styles.prevDateEvent : {},
-                    isLastRow ? styles.lastRowEvent : {},
-                  ]}
-                >
-                  <TouchableOpacity
-                    style={[
-                      styles.event,
-                      {
-                        backgroundColor: event.backgroundColor,
-                        borderColor: event.borderColor,
-                        ...(event.borderStyle !== undefined && {
-                          borderStyle: event.borderStyle,
-                        }),
-                        ...(event.borderWidth !== undefined && {
-                          borderWidth: event.borderWidth,
-                        }),
-                        ...(event.borderRadius !== undefined && {
-                          borderRadius: event.borderRadius,
-                        }),
-                      },
-                    ]}
-                    onPress={() => {
-                      props.onPressEvent?.(event);
-                    }}
-                    onLongPress={() => {
-                      props.onLongPressEvent?.(event);
-                    }}
-                    delayLongPress={props.delayLongPressEvent}
-                  >
-                    <Text
-                      numberOfLines={1}
-                      ellipsizeMode={props.eventEllipsizeMode ?? 'tail'}
-                      style={[
-                        styles.eventTitle,
-                        { color: event.color },
-                        props.eventTextStyle?.(event),
-                      ]}
-                      allowFontScaling={props.allowFontScaling}
-                    >
-                      {event.title}
-                    </Text>
-                  </TouchableOpacity>
-                  {showEventOverlay ? (
-                    <View
-                      style={styles.eventOverlayHost}
-                      pointerEvents="box-none"
-                    >
-                      {eventOverlayNode}
-                    </View>
-                  ) : null}
-                </View>
-              );
-            })}
+        return showPrioritizedCellOverlay ? (
+          <View key={djs.valueOf()} style={cellWrapperStyle}>
+            {cellInner}
+            <TouchableOpacity
+              accessible={false}
+              style={styles.cellInteractionOverlay}
+              activeOpacity={1}
+              onPress={() => {
+                props.onPressCell?.(djs.toDate());
+              }}
+              onLongPress={() => {
+                props.onLongPressCell?.(djs.toDate());
+              }}
+              delayLongPress={props.delayLongPressCell}
+            />
+          </View>
+        ) : (
+          <TouchableOpacity
+            key={djs.valueOf()}
+            style={cellWrapperStyle}
+            onPress={() => {
+              props.onPressCell?.(djs.toDate());
+            }}
+            onLongPress={() => {
+              props.onLongPressCell?.(djs.toDate());
+            }}
+            delayLongPress={props.delayLongPressCell}
+          >
+            {cellInner}
           </TouchableOpacity>
         );
       })}
@@ -313,5 +341,9 @@ const styles = StyleSheet.create({
   },
   eventTitle: {
     fontSize: 12,
+  },
+  cellInteractionOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1000,
   },
 });

--- a/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import type { ReactNode } from 'react';
 import {
+  Platform,
   StyleSheet,
   useWindowDimensions,
   type LayoutChangeEvent,
@@ -161,6 +162,7 @@ export const MonthCalendarWeekRow = (props: {
           return (
             <View
               key={event.id}
+              pointerEvents={showPrioritizedCellOverlay ? 'none' : 'auto'}
               style={[
                 styles.eventOuter,
                 {
@@ -345,5 +347,10 @@ const styles = StyleSheet.create({
   cellInteractionOverlay: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 1000,
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      android: { elevation: 12 },
+      default: {},
+    }),
   },
 });

--- a/src/calendar/resources-calendar/ResourcesCalendar.tsx
+++ b/src/calendar/resources-calendar/ResourcesCalendar.tsx
@@ -14,6 +14,7 @@ import {
   type NativeSyntheticEvent,
   type TextStyle,
   type ViewStyle,
+  Platform,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -244,6 +245,7 @@ function ResourceRow({
             return (
               <View
                 key={event.id}
+                pointerEvents={showPrioritizedCellOverlay ? 'none' : 'auto'}
                 style={[
                   styles.eventOuter,
                   { width, height: eventHeight },
@@ -763,6 +765,11 @@ const styles = StyleSheet.create({
   cellInteractionOverlay: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 1000,
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      android: { elevation: 12 },
+      default: {},
+    }),
   },
   container: {
     flex: 1,

--- a/src/calendar/resources-calendar/ResourcesCalendar.tsx
+++ b/src/calendar/resources-calendar/ResourcesCalendar.tsx
@@ -55,6 +55,12 @@ type ResourcesCalendarProps = {
   hiddenMonth?: boolean;
   allowFontScaling?: boolean;
   resourceNameLayout?: 'fixed-column' | 'inline-band';
+  /**
+   * When true, a transparent layer is placed above events in each cell so
+   * `onPressCell` / `onLongPressCell` receive touches for the full cell area.
+   * Event taps are disabled while this is on (overlay captures the gesture).
+   */
+  prioritizeCellInteraction?: boolean;
 };
 
 const DEFAULT_DATE_COLUMN_WIDTH = 60;
@@ -84,6 +90,7 @@ type ResourceRowProps = {
     scrollOffset: number;
     renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
   };
+  prioritizeCellInteraction?: boolean;
 };
 
 function ResourceRow({
@@ -105,6 +112,7 @@ function ResourceRow({
   allowFontScaling,
   onLayout,
   inlineBand,
+  prioritizeCellInteraction,
 }: ResourceRowProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
   const eventPosition = new ResourcesCalendarEventPosition();
@@ -178,125 +186,151 @@ function ResourceRow({
             }
           }
 
-          return (
-            <TouchableOpacity
-              key={date.getTime()}
-              style={[
-                styles.contentCellContainer,
-                { width: dateColumnWidth },
-                { zIndex: dates.length - dateIndex },
-              ]}
-              onPress={() => onPressCell?.(resource, date)}
-              onLongPress={() => onLongPressCell?.(resource, date)}
-              delayLongPress={delayLongPressCell}
-              activeOpacity={1}
-            >
+          const showPrioritizedCellOverlay =
+            prioritizeCellInteraction === true &&
+            (onPressCell != null || onLongPressCell != null);
+
+          const cellWrapperStyle = [
+            styles.contentCellContainer,
+            { width: dateColumnWidth },
+            { zIndex: dates.length - dateIndex },
+          ];
+
+          const eventRows = cellEvents.map((event, rowIndex) => {
+            if (typeof event === 'number') {
+              return (
+                <View
+                  key={`spacer-${rowIndex}`}
+                  style={{
+                    height: eventHeight,
+                    marginBottom: EVENT_GAP,
+                  }}
+                />
+              );
+            }
+
+            const rawStartDjs = dayjs(event.start);
+            const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
+            const endDjs = dayjs(event.end);
+            const diffDays = endDjs
+              .startOf('day')
+              .diff(startDjs.startOf('day'), 'day');
+            const isPrevDateEvent =
+              dateIndex === 0 && rawStartDjs.isBefore(djs);
+
+            // Calculate event width based on the number of days it spans
+            let width =
+              (diffDays + 1) * dateColumnWidth -
+              EVENT_GAP * 2 -
+              CELL_BORDER_WIDTH * 2;
+            if (isPrevDateEvent) {
+              width += EVENT_GAP + 1;
+            }
+
+            // Record position info
+            eventPosition.push({
+              resourceId: resource.id,
+              startDate: startDjs.toDate(),
+              days: diffDays + 1,
+              rowNum: rowIndex + 1,
+            });
+
+            const eventOverlayNode = renderEventOverlay?.(event);
+            const showEventOverlay =
+              renderEventOverlay != null &&
+              eventOverlayNode != null &&
+              eventOverlayNode !== false;
+
+            return (
+              <View
+                key={event.id}
+                style={[
+                  styles.eventOuter,
+                  { width, height: eventHeight },
+                  isPrevDateEvent ? styles.prevDateEvent : {},
+                ]}
+              >
+                <TouchableOpacity
+                  data-component-name="resources-calendar-event"
+                  style={[
+                    styles.event,
+                    {
+                      backgroundColor: event.backgroundColor,
+                      borderColor: event.borderColor,
+                      ...(event.borderStyle !== undefined && {
+                        borderStyle: event.borderStyle,
+                      }),
+                      ...(event.borderWidth !== undefined && {
+                        borderWidth: event.borderWidth,
+                      }),
+                      ...(event.borderRadius !== undefined && {
+                        borderRadius: event.borderRadius,
+                      }),
+                    },
+                  ]}
+                  onPress={() => onPressEvent?.(event)}
+                  onLongPress={() => onLongPressEvent?.(event)}
+                  delayLongPress={delayLongPressEvent}
+                >
+                  <Text
+                    numberOfLines={1}
+                    ellipsizeMode={eventEllipsizeMode ?? 'tail'}
+                    allowFontScaling={allowFontScaling}
+                    style={[
+                      styles.eventTitle,
+                      { color: event.color },
+                      eventTextStyle?.(event),
+                    ]}
+                  >
+                    {event.title}
+                  </Text>
+                </TouchableOpacity>
+                {showEventOverlay ? (
+                  <View
+                    style={styles.eventOverlayHost}
+                    pointerEvents="box-none"
+                  >
+                    {eventOverlayNode}
+                  </View>
+                ) : null}
+              </View>
+            );
+          });
+
+          const cellInner = (
+            <>
               <View
                 style={[
                   styles.contentCellContainerInner,
                   cellContainerStyle?.(resource, date),
                 ]}
               />
-              {cellEvents.map((event, rowIndex) => {
-                if (typeof event === 'number') {
-                  return (
-                    <View
-                      key={`spacer-${rowIndex}`}
-                      style={{
-                        height: eventHeight,
-                        marginBottom: EVENT_GAP,
-                      }}
-                    />
-                  );
-                }
+              {eventRows}
+            </>
+          );
 
-                const rawStartDjs = dayjs(event.start);
-                const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
-                const endDjs = dayjs(event.end);
-                const diffDays = endDjs
-                  .startOf('day')
-                  .diff(startDjs.startOf('day'), 'day');
-                const isPrevDateEvent =
-                  dateIndex === 0 && rawStartDjs.isBefore(djs);
-
-                // Calculate event width based on the number of days it spans
-                let width =
-                  (diffDays + 1) * dateColumnWidth -
-                  EVENT_GAP * 2 -
-                  CELL_BORDER_WIDTH * 2;
-                if (isPrevDateEvent) {
-                  width += EVENT_GAP + 1;
-                }
-
-                // Record position info
-                eventPosition.push({
-                  resourceId: resource.id,
-                  startDate: startDjs.toDate(),
-                  days: diffDays + 1,
-                  rowNum: rowIndex + 1,
-                });
-
-                const eventOverlayNode = renderEventOverlay?.(event);
-                const showEventOverlay =
-                  renderEventOverlay != null &&
-                  eventOverlayNode != null &&
-                  eventOverlayNode !== false;
-
-                return (
-                  <View
-                    key={event.id}
-                    style={[
-                      styles.eventOuter,
-                      { width, height: eventHeight },
-                      isPrevDateEvent ? styles.prevDateEvent : {},
-                    ]}
-                  >
-                    <TouchableOpacity
-                      data-component-name="resources-calendar-event"
-                      style={[
-                        styles.event,
-                        {
-                          backgroundColor: event.backgroundColor,
-                          borderColor: event.borderColor,
-                          ...(event.borderStyle !== undefined && {
-                            borderStyle: event.borderStyle,
-                          }),
-                          ...(event.borderWidth !== undefined && {
-                            borderWidth: event.borderWidth,
-                          }),
-                          ...(event.borderRadius !== undefined && {
-                            borderRadius: event.borderRadius,
-                          }),
-                        },
-                      ]}
-                      onPress={() => onPressEvent?.(event)}
-                      onLongPress={() => onLongPressEvent?.(event)}
-                      delayLongPress={delayLongPressEvent}
-                    >
-                      <Text
-                        numberOfLines={1}
-                        ellipsizeMode={eventEllipsizeMode ?? 'tail'}
-                        allowFontScaling={allowFontScaling}
-                        style={[
-                          styles.eventTitle,
-                          { color: event.color },
-                          eventTextStyle?.(event),
-                        ]}
-                      >
-                        {event.title}
-                      </Text>
-                    </TouchableOpacity>
-                    {showEventOverlay ? (
-                      <View
-                        style={styles.eventOverlayHost}
-                        pointerEvents="box-none"
-                      >
-                        {eventOverlayNode}
-                      </View>
-                    ) : null}
-                  </View>
-                );
-              })}
+          return showPrioritizedCellOverlay ? (
+            <View key={date.getTime()} style={cellWrapperStyle}>
+              {cellInner}
+              <TouchableOpacity
+                accessible={false}
+                style={styles.cellInteractionOverlay}
+                activeOpacity={1}
+                onPress={() => onPressCell?.(resource, date)}
+                onLongPress={() => onLongPressCell?.(resource, date)}
+                delayLongPress={delayLongPressCell}
+              />
+            </View>
+          ) : (
+            <TouchableOpacity
+              key={date.getTime()}
+              style={cellWrapperStyle}
+              onPress={() => onPressCell?.(resource, date)}
+              onLongPress={() => onLongPressCell?.(resource, date)}
+              delayLongPress={delayLongPressCell}
+              activeOpacity={1}
+            >
+              {cellInner}
             </TouchableOpacity>
           );
         })}
@@ -458,6 +492,7 @@ export function ResourcesCalendar(props: ResourcesCalendarProps) {
           renderResourceNameLabel: props.renderResourceNameLabel,
         }
       : undefined,
+    prioritizeCellInteraction: props.prioritizeCellInteraction,
   };
 
   const resourceNameColumn = !isInlineBand ? (
@@ -724,6 +759,10 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+  },
+  cellInteractionOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1000,
   },
   container: {
     flex: 1,


### PR DESCRIPTION
## Summary
Adds an optional `prioritizeCellInteraction` prop to **MonthCalendar** and **ResourcesCalendar**. When enabled (and `onPressCell` or `onLongPressCell` is provided), each day cell gets a full-size transparent overlay above events so cell handlers receive taps/long-presses across the whole cell.

## Details
- Transparent overlay with `onPress` / `onLongPress` wired to the existing cell callbacks
- Spanning events: event containers use `pointerEvents="none"` in this mode so touches on overlapped columns reach the correct cell\u0027s overlay
- Overlay styling: `backgroundColor: 'transparent'`, Android `elevation` for reliable hit testing
- Example app: shared switch toggles the option for both calendars; label in English

## Commits
- `feat(resources-calendar): add prioritizeCellInteraction for full-cell taps`
- `feat(month-calendar): add prioritizeCellInteraction for full-cell taps`
- `fix: let cell overlay receive taps under spanning events (pointerEvents + hit area)`
- `docs(example): use English label for prioritize cell taps switch`

Made with [Cursor](https://cursor.com)