### PR TITLE
feat: add WeekResourcesCalendar

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,9 @@
+{
+  "format_on_save": "on",
+  "formatter": "prettier",
+  "languages": {
+    "Markdown": {
+      "format_on_save": "off"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # react-native-ll-calendar
 
-A horizontally scrollable monthly calendar component for React Native with event support.
+A collection of horizontally scrollable calendar components for React Native with event support.
+
+- **MonthCalendar** — month view, swipe left/right to change months
+- **ResourcesCalendar** — resource × date grid, horizontal scroll across a date range
+- **WeekResourcesCalendar** — resource × date grid, swipe left/right to change weeks
 
 <img src="assets/screen-shot.png" width="320px">
 
@@ -138,26 +142,111 @@ You can access these methods by passing a `ref` to the `MonthCalendar` component
 | `borderWidth`     | `number`                                | No       | Border width                   |
 | `borderRadius`    | `number`                                | No       | Border radius                  |
 
+---
+
+### ResourcesCalendar Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `fromDate` | `Date` | Yes | - | Start of the displayed date range |
+| `toDate` | `Date` | Yes | - | End of the displayed date range |
+| `resources` | `CalendarResource[]` | Yes | - | List of resources (rows) |
+| `events` | `ResourcesCalendarEvent[]` | Yes | - | Array of resource events |
+| `renderDateLabel` | `(date: Date) => JSX.Element` | No | - | Custom header date cell content |
+| `renderMonthLabel` | `(year: number, month: number) => JSX.Element` | No | - | Custom month label content |
+| `renderResourceNameLabel` | `(resource: CalendarResource) => JSX.Element` | No | - | Custom resource name cell content |
+| `resourceColumnWidth` | `number` | No | `80` | Width of the resource name column |
+| `dateColumnWidth` | `number` | No | `60` | Width of each date column |
+| `onRefresh` | `() => void` | No | - | Callback for pull-to-refresh |
+| `refreshing` | `boolean` | No | - | Whether the calendar is refreshing |
+| `fixedRowCount` | `number` | No | `0` | Number of resource rows pinned above the scroll area |
+| `onPressCell` | `(resource: CalendarResource, date: Date) => void` | No | - | Callback when a cell is pressed |
+| `onLongPressCell` | `(resource: CalendarResource, date: Date) => void` | No | - | Callback when a cell is long pressed |
+| `delayLongPressCell` | `number` | No | - | Delay in ms before long press is triggered |
+| `onPressEvent` | `(event: ResourcesCalendarEvent) => void` | No | - | Callback when an event is pressed |
+| `onLongPressEvent` | `(event: ResourcesCalendarEvent) => void` | No | - | Callback when an event is long pressed |
+| `delayLongPressEvent` | `number` | No | - | Delay in ms before long press is triggered |
+| `eventHeight` | `number` | No | `22` | Height of event items in pixels |
+| `bottomSpacing` | `number` | No | - | Bottom spacing in pixels for scrollable content |
+| `eventTextStyle` | `(event: ResourcesCalendarEvent) => TextStyle` | No | - | Style function for event text |
+| `eventEllipsizeMode` | `'head' \| 'middle' \| 'tail' \| 'clip'` | No | `'tail'` | Ellipsize mode for event text |
+| `renderEventOverlay` | `(event: ResourcesCalendarEvent) => ReactNode` | No | - | Optional overlay above each event |
+| `dateCellContainerStyle` | `(date: Date) => ViewStyle` | No | - | Style for header date cells |
+| `cellContainerStyle` | `(resource: CalendarResource, date: Date) => ViewStyle` | No | - | Style for resource day cell background |
+| `hiddenMonth` | `boolean` | No | `false` | Hide the month header row |
+| `allowFontScaling` | `boolean` | No | - | Enable font scaling for text elements |
+| `resourceNameLayout` | `'fixed-column' \| 'inline-band'` | No | `'fixed-column'` | Layout mode for the resource name |
+| `prioritizeCellInteraction` | `boolean` | No | `false` | Overlay to prioritize cell taps over events |
+
+### CalendarResource
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | Yes | Unique identifier |
+| `name` | `string` | Yes | Display name |
+
+### ResourcesCalendarEvent
+
+Same fields as `CalendarEvent` with the addition of:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `resourceId` | `string` | Yes | ID of the resource this event belongs to |
+
+---
+
+### WeekResourcesCalendar Props
+
+| Prop | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `defaultDate` | `Date` | Yes | - | Initial date to display |
+| `weekStartsOn` | `0 \| 1` | No | `0` | Week start day (0 = Sunday, 1 = Monday) |
+| `onChangeDate` | `(date: Date) => void` | No | - | Callback when the displayed week changes |
+| `resources` | `CalendarResource[]` | Yes | - | List of resources (rows) |
+| `events` | `ResourcesCalendarEvent[]` | Yes | - | Array of resource events |
+| `eventHeight` | `number` | No | `22` | Height of event items in pixels |
+| `onPressCell` | `(resource: CalendarResource, date: Date) => void` | No | - | Callback when a cell is pressed |
+| `onLongPressCell` | `(resource: CalendarResource, date: Date) => void` | No | - | Callback when a cell is long pressed |
+| `delayLongPressCell` | `number` | No | - | Delay in ms before long press is triggered |
+| `onPressEvent` | `(event: ResourcesCalendarEvent) => void` | No | - | Callback when an event is pressed |
+| `onLongPressEvent` | `(event: ResourcesCalendarEvent) => void` | No | - | Callback when an event is long pressed |
+| `delayLongPressEvent` | `number` | No | - | Delay in ms before long press is triggered |
+| `prioritizeCellInteraction` | `boolean` | No | `false` | Overlay to prioritize cell taps over events |
+| `eventTextStyle` | `(event: ResourcesCalendarEvent) => TextStyle` | No | - | Style function for event text |
+| `eventEllipsizeMode` | `'head' \| 'middle' \| 'tail' \| 'clip'` | No | `'tail'` | Ellipsize mode for event text |
+| `allowFontScaling` | `boolean` | No | - | Enable font scaling for text elements |
+| `renderEventOverlay` | `(event: ResourcesCalendarEvent) => ReactNode` | No | - | Optional overlay above each event |
+| `dateCellContainerStyle` | `(date: Date) => ViewStyle` | No | - | Style for header date cells |
+| `cellContainerStyle` | `(resource: CalendarResource, date: Date) => ViewStyle` | No | - | Style for resource day cell background |
+| `renderDateLabel` | `(date: Date) => JSX.Element` | No | - | Custom header date cell content |
+| `renderResourceNameLabel` | `(resource: CalendarResource) => JSX.Element` | No | - | Custom resource name cell content |
+| `onRefresh` | `() => void` | No | - | Callback for pull-to-refresh |
+| `refreshing` | `boolean` | No | - | Whether the calendar is refreshing |
+| `bottomSpacing` | `number` | No | - | Bottom spacing in pixels for scrollable content |
+| `fixedRowCount` | `number` | No | `0` | Number of resource rows pinned above the scroll area |
+
+---
+
 ## Features
 
-- Horizontally scrollable month view
-- Multi-day event support
+- Horizontally scrollable month view (±10 years)
+- Horizontally scrollable week resource view (±120 weeks)
+- Resource × date grid view across a custom date range
+- Multi-day event support with overlap stacking
 - Customizable event colors and border styles
 - Event press handlers (tap and long press)
-- Date cell press handlers (tap and long press)
+- Cell press handlers (tap and long press)
+- `prioritizeCellInteraction` to route taps to cells over events
 - Configurable week start day (Sunday or Monday)
-- Customizable styling for day cells, weekday cells, and today's cell
 - Pull-to-refresh support
+- Fixed row pinning for resource calendars
+- Custom render props for date labels, month labels, and resource names
+- Event overlay support (e.g. badge counts)
 - Locale support for internationalization
-- Optional month header visibility control
-- Custom month format display
-- Sticky header support for month and week rows
-- Customizable cell border colors
 - Font scaling control for text elements
 - Customizable event height and text styles
-- Spans 10 years before and after the default date
-- **Programmatic scroll control via Ref**
-- **Dynamic row height retrieval via Ref**
+- **Programmatic scroll control via Ref** (MonthCalendar)
+- **Dynamic row height retrieval via Ref** (MonthCalendar)
 
 ## License
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -835,6 +835,20 @@ export default function App() {
           onChangeDate={(d) => {
             console.log('week changed', dayjs(d).format('YYYY-MM-DD'));
           }}
+          onPressCell={(resource, d) => {
+            console.log(
+              'week onPressCell',
+              resource.name,
+              dayjs(d).format('YYYY-MM-DD')
+            );
+          }}
+          onLongPressCell={(resource, d) => {
+            console.log(
+              'week onLongPressCell',
+              resource.name,
+              dayjs(d).format('YYYY-MM-DD')
+            );
+          }}
           onPressEvent={(event) => {
             console.log('week onPressEvent', event.id, event.title);
           }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -856,6 +856,9 @@ export default function App() {
             console.log('week onLongPressEvent', event.id, event.title);
           }}
           prioritizeCellInteraction={prioritizeCellInteraction}
+          eventTextStyle={(_event) => ({ fontSize: 12 })}
+          eventEllipsizeMode={'clip'}
+          allowFontScaling={false}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -829,6 +829,7 @@ export default function App() {
         <WeekResourcesCalendar
           defaultDate={new Date()}
           weekStartsOn={1}
+          resources={resources}
           onChangeDate={(d) => {
             console.log('week changed', dayjs(d).format('YYYY-MM-DD'));
           }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -855,6 +855,7 @@ export default function App() {
           onLongPressEvent={(event) => {
             console.log('week onLongPressEvent', event.id, event.title);
           }}
+          prioritizeCellInteraction={prioritizeCellInteraction}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -835,6 +835,12 @@ export default function App() {
           onChangeDate={(d) => {
             console.log('week changed', dayjs(d).format('YYYY-MM-DD'));
           }}
+          onPressEvent={(event) => {
+            console.log('week onPressEvent', event.id, event.title);
+          }}
+          onLongPressEvent={(event) => {
+            console.log('week onLongPressEvent', event.id, event.title);
+          }}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -908,6 +908,7 @@ export default function App() {
               <Text style={styles.resourceNameText}>{resource.name}</Text>
             </View>
           )}
+          bottomSpacing={200}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -831,6 +831,8 @@ export default function App() {
           weekStartsOn={1}
           resources={resources}
           events={resourceEvents}
+          onRefresh={handleRefresh}
+          refreshing={refreshing}
           eventHeight={22}
           onChangeDate={(d) => {
             console.log('week changed', dayjs(d).format('YYYY-MM-DD'));

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,6 +7,7 @@ import {
   MonthCalendar,
   MonthCalendarEventOverlay,
   ResourcesCalendar,
+  WeekResourcesCalendar,
   type CalendarEvent,
   type ResourcesCalendarEvent,
   type CalendarResource,
@@ -15,7 +16,11 @@ import type { WeekdayNum } from '../../src/types/month-calendar';
 import type { TextStyle } from 'react-native';
 import type { MonthCalendarRef } from '../../src/calendar/month-calendar/MonthCalendar';
 
-type TabType = 'month' | 'resources-fixed-column' | 'resources-inline-band';
+type TabType =
+  | 'month'
+  | 'resources-fixed-column'
+  | 'resources-inline-band'
+  | 'week-resources';
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabType>('month');
@@ -791,6 +796,22 @@ export default function App() {
             Inline Band
           </Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.tab,
+            activeTab === 'week-resources' && styles.activeTab,
+          ]}
+          onPress={() => setActiveTab('week-resources')}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeTab === 'week-resources' && styles.activeTabText,
+            ]}
+          >
+            Week
+          </Text>
+        </TouchableOpacity>
       </View>
 
       <View style={styles.resourcesOptionRow}>
@@ -804,7 +825,15 @@ export default function App() {
       </View>
 
       {/* Content */}
-      {activeTab === 'month' ? (
+      {activeTab === 'week-resources' ? (
+        <WeekResourcesCalendar
+          defaultDate={new Date()}
+          weekStartsOn={1}
+          onChangeDate={(d) => {
+            console.log('week changed', dayjs(d).format('YYYY-MM-DD'));
+          }}
+        />
+      ) : activeTab === 'month' ? (
         <MonthCalendar
           ref={calendarRef}
           defaultDate={date}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -442,7 +442,7 @@ export default function App() {
         id: 're-r1-a',
         resourceId: 'r1',
         title: 'Event A (1-5)',
-        start: new Date(y, m, 1),
+        start: new Date(y, m, 0),
         end: new Date(y, m, 5),
         backgroundColor: '#ff6b6b',
         borderColor: '#e55353',
@@ -830,6 +830,8 @@ export default function App() {
           defaultDate={new Date()}
           weekStartsOn={1}
           resources={resources}
+          events={resourceEvents}
+          eventHeight={22}
           onChangeDate={(d) => {
             console.log('week changed', dayjs(d).format('YYYY-MM-DD'));
           }}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -859,6 +859,7 @@ export default function App() {
           eventTextStyle={(_event) => ({ fontSize: 12 })}
           eventEllipsizeMode={'clip'}
           allowFontScaling={false}
+          renderEventOverlay={renderResourcesEventOverlay}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -878,6 +878,34 @@ export default function App() {
               }),
             };
           }}
+          renderDateLabel={(d) => {
+            const isToday = dayjs(d).isSame(dayjs(), 'day');
+            const todayStyle = {
+              backgroundColor: 'green',
+              borderRadius: 12,
+              width: '100%',
+            };
+            const todayTextStyle = { color: 'white' };
+            return (
+              <View style={[styles.dateLabel, isToday ? todayStyle : {}]}>
+                <Text
+                  style={[styles.dateLabelText, isToday ? todayTextStyle : {}]}
+                >
+                  {dayjs(d).locale(ja).format('M/D')}
+                </Text>
+                <Text
+                  style={[styles.dateLabelText, isToday ? todayTextStyle : {}]}
+                >
+                  {dayjs(d).locale(ja).format('(ddd)')}
+                </Text>
+              </View>
+            );
+          }}
+          renderResourceNameLabel={(resource) => (
+            <View>
+              <Text style={styles.resourceNameText}>{resource.name}</Text>
+            </View>
+          )}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar
@@ -1053,6 +1081,11 @@ const styles = StyleSheet.create({
   },
   monthLabelText: {
     fontSize: 12,
+    color: '#333',
+    fontWeight: '600',
+  },
+  resourceNameText: {
+    fontSize: 11,
     color: '#333',
     fontWeight: '600',
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -860,6 +860,24 @@ export default function App() {
           eventEllipsizeMode={'clip'}
           allowFontScaling={false}
           renderEventOverlay={renderResourcesEventOverlay}
+          dateCellContainerStyle={(d) => {
+            if (d.getDay() === 0 || d.getDay() === 6) {
+              return { backgroundColor: '#f5f5f5' };
+            }
+            return { backgroundColor: '#fff' };
+          }}
+          cellContainerStyle={(resource, d) => {
+            const isWeekend = d.getDay() === 0 || d.getDay() === 6;
+            const isToday = dayjs(d).isSame(dayjs(), 'day');
+            const isHighlighted = resource.id === 'r1' && isToday;
+            return {
+              backgroundColor: isWeekend ? '#f5f5f5' : '#fff',
+              ...(isHighlighted && {
+                borderWidth: 3,
+                borderColor: '#ff0000',
+              }),
+            };
+          }}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -909,6 +909,7 @@ export default function App() {
             </View>
           )}
           bottomSpacing={200}
+          fixedRowCount={2}
         />
       ) : activeTab === 'month' ? (
         <MonthCalendar

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -1,20 +1,207 @@
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import dayjs from 'dayjs';
-import type { CalendarResource } from '../../types/resources-calendar';
+import { useMemo } from 'react';
+import type {
+  CalendarResource,
+  CalendarEvent,
+} from '../../types/resources-calendar';
+import ResourcesCalendarEventPosition from '../../utils/resources-calendar-event-position';
+import { EVENT_GAP } from '../../constants/size';
 
 export const CELL_BORDER_WIDTH = 0.5;
 export const BORDER_COLOR = 'lightslategrey';
+const DEFAULT_EVENT_HEIGHT = 22;
 
 export type WeekPanelProps = {
   weekKey: string;
   width: number;
   resources: CalendarResource[];
+  events: CalendarEvent[];
+  eventHeight?: number;
 };
 
-export function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
+type DayCellProps = {
+  resource: CalendarResource;
+  date: dayjs.Dayjs;
+  dateIndex: number;
+  columnWidth: number;
+  eventHeight: number;
+  eventPosition: ResourcesCalendarEventPosition;
+  eventsByResourceId: Map<string, CalendarEvent[]>;
+};
+
+function DayCell({
+  resource,
+  date,
+  dateIndex,
+  columnWidth,
+  eventHeight,
+  eventPosition,
+  eventsByResourceId,
+}: DayCellProps) {
+  const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
+
+  const filteredEvents = resourceEvents
+    .filter((event) => {
+      const startDjs = dayjs(event.start);
+      const endDjs = dayjs(event.end);
+      return (
+        startDjs.format('YYYY-MM-DD') === date.format('YYYY-MM-DD') ||
+        (dateIndex === 0 &&
+          startDjs.isBefore(date) &&
+          !endDjs.startOf('day').isBefore(date.startOf('day')))
+      );
+    })
+    .sort((a, b) => {
+      const aStartDjs = dateIndex === 0 ? date : dayjs(a.start);
+      const bStartDjs = dateIndex === 0 ? date : dayjs(b.start);
+      const aDiffDays = dayjs(a.end)
+        .startOf('day')
+        .diff(aStartDjs.startOf('day'), 'day');
+      const bDiffDays = dayjs(b.end)
+        .startOf('day')
+        .diff(bStartDjs.startOf('day'), 'day');
+      if (aDiffDays !== bDiffDays) {
+        return bDiffDays - aDiffDays;
+      }
+      return dayjs(a.start).diff(dayjs(b.start));
+    });
+
+  const rowNums = eventPosition.getRowNums({
+    resourceId: resource.id,
+    date: date.toDate(),
+  });
+  const cellEvents: (CalendarEvent | number)[] = [];
+  const rowsLength = rowNums.length + filteredEvents.length;
+  let eventIndex = 0;
+  for (let ii = 1; ii <= rowsLength; ii++) {
+    if (rowNums.includes(ii)) {
+      cellEvents.push(ii);
+    } else {
+      const event = filteredEvents[eventIndex];
+      if (event) {
+        cellEvents.push(event);
+      }
+      eventIndex++;
+    }
+  }
+
+  return (
+    <View
+      style={[styles.dayCell, { width: columnWidth, zIndex: 7 - dateIndex }]}
+    >
+      <View style={styles.dayCellBackground} />
+      {cellEvents.map((event, rowIndex) => {
+        if (typeof event === 'number') {
+          return (
+            <View
+              key={`spacer-${rowIndex}`}
+              style={{ height: eventHeight, marginBottom: EVENT_GAP }}
+            />
+          );
+        }
+
+        const rawStartDjs = dayjs(event.start);
+        const startDjs = dateIndex === 0 ? date : rawStartDjs;
+        const endDjs = dayjs(event.end);
+        const diffDaysRaw = endDjs
+          .startOf('day')
+          .diff(startDjs.startOf('day'), 'day');
+        // 週の残り日数に収める
+        const maxDiff = 6 - dateIndex;
+        const diffDays = Math.min(diffDaysRaw, maxDiff);
+        const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(date);
+
+        let width =
+          (diffDays + 1) * columnWidth - EVENT_GAP * 2 - CELL_BORDER_WIDTH * 2;
+        if (isPrevDateEvent) {
+          width += EVENT_GAP + 1;
+        }
+
+        eventPosition.push({
+          resourceId: resource.id,
+          startDate: startDjs.toDate(),
+          days: diffDays + 1,
+          rowNum: rowIndex + 1,
+        });
+
+        return (
+          <View
+            key={event.id}
+            style={[
+              styles.eventOuter,
+              { width, height: eventHeight },
+              isPrevDateEvent && styles.prevDateEvent,
+            ]}
+          >
+            <TouchableOpacity
+              style={[
+                styles.event,
+                {
+                  backgroundColor: event.backgroundColor,
+                  borderColor: event.borderColor,
+                  ...(event.borderStyle !== undefined && {
+                    borderStyle: event.borderStyle,
+                  }),
+                  ...(event.borderWidth !== undefined && {
+                    borderWidth: event.borderWidth,
+                  }),
+                  ...(event.borderRadius !== undefined && {
+                    borderRadius: event.borderRadius,
+                  }),
+                },
+              ]}
+              activeOpacity={0.8}
+            >
+              <Text
+                numberOfLines={1}
+                style={[styles.eventTitle, { color: event.color }]}
+              >
+                {event.title}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export function WeekPanel({
+  weekKey,
+  width,
+  resources,
+  events,
+  eventHeight,
+}: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
   const days = Array.from({ length: 7 }, (_, i) => startDjs.add(i, 'day'));
+  const resolvedEventHeight = eventHeight ?? DEFAULT_EVENT_HEIGHT;
+
+  const eventsByResourceId = useMemo(() => {
+    const deduped = new Map<string, CalendarEvent>();
+    for (const event of events) {
+      deduped.set(event.id, event);
+    }
+    const map = new Map<string, CalendarEvent[]>();
+    for (const event of deduped.values()) {
+      const list = map.get(event.resourceId) ?? [];
+      list.push(event);
+      map.set(event.resourceId, list);
+    }
+    return map;
+  }, [events]);
+
+  // パネル全体で1インスタンス（resourceIdで区別される）
+  const eventPosition = new ResourcesCalendarEventPosition();
 
   return (
     <View style={[styles.panel, { width }]}>
@@ -45,15 +232,23 @@ export function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
             key={resource.id}
             style={[styles.resourceRow, index === 0 && styles.resourceRowFirst]}
           >
+            {/* リソース名セル */}
             <View style={[styles.resourceNameCell, { width: columnWidth }]}>
               <Text style={styles.resourceNameText} numberOfLines={2}>
                 {resource.name}
               </Text>
             </View>
-            {days.map((day) => (
-              <View
+            {/* 日付セル */}
+            {days.map((day, dateIndex) => (
+              <DayCell
                 key={day.format('YYYY-MM-DD')}
-                style={[styles.dayCell, { width: columnWidth }]}
+                resource={resource}
+                date={day}
+                dateIndex={dateIndex}
+                columnWidth={columnWidth}
+                eventHeight={resolvedEventHeight}
+                eventPosition={eventPosition}
+                eventsByResourceId={eventsByResourceId}
               />
             ))}
           </View>
@@ -119,5 +314,37 @@ const styles = StyleSheet.create({
     borderRightWidth: CELL_BORDER_WIDTH,
     borderRightColor: BORDER_COLOR,
     minHeight: 48,
+    paddingBottom: EVENT_GAP,
+    position: 'relative',
+  },
+  dayCellBackground: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  eventOuter: {
+    position: 'relative',
+    marginTop: EVENT_GAP,
+    marginLeft: EVENT_GAP,
+  },
+  prevDateEvent: {
+    marginLeft: -1,
+    borderTopStartRadius: 0,
+    borderBottomStartRadius: 0,
+  },
+  event: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    borderWidth: 0.5,
+    borderRadius: 4,
+    paddingHorizontal: 4,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Platform.select({
+      android: { elevation: 2 },
+      default: {},
+    }),
+  },
+  eventTitle: {
+    fontSize: 11,
   },
 });

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -46,6 +46,7 @@ export type WeekPanelProps = {
   onRefresh?: () => void;
   refreshing?: boolean;
   bottomSpacing?: number;
+  fixedRowCount?: number;
 };
 
 type DayCellProps = {
@@ -298,11 +299,13 @@ export function WeekPanel({
   onRefresh,
   refreshing,
   bottomSpacing,
+  fixedRowCount,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
   const days = Array.from({ length: 7 }, (_, i) => startDjs.add(i, 'day'));
   const resolvedEventHeight = eventHeight ?? DEFAULT_EVENT_HEIGHT;
+  const resolvedFixedRowCount = fixedRowCount ?? 0;
 
   const eventsByResourceId = useMemo(() => {
     const deduped = new Map<string, CalendarEvent>();
@@ -318,8 +321,67 @@ export function WeekPanel({
     return map;
   }, [events]);
 
+  const fixedResources = useMemo(
+    () => resources.slice(0, resolvedFixedRowCount),
+    [resources, resolvedFixedRowCount]
+  );
+  const scrollableResources = useMemo(
+    () => resources.slice(resolvedFixedRowCount),
+    [resources, resolvedFixedRowCount]
+  );
+
   // パネル全体で1インスタンス（resourceIdで区別される）
   const eventPosition = new ResourcesCalendarEventPosition();
+
+  const renderResourceRow = (
+    resource: CalendarResource,
+    showTopBorder: boolean
+  ) => (
+    <View
+      key={resource.id}
+      style={[styles.resourceRow, showTopBorder && styles.resourceRowFirst]}
+    >
+      {/* リソース名セル */}
+      <View style={[styles.resourceNameCell, { width: columnWidth }]}>
+        {renderResourceNameLabel ? (
+          renderResourceNameLabel(resource)
+        ) : (
+          <Text
+            style={styles.resourceNameText}
+            numberOfLines={2}
+            allowFontScaling={allowFontScaling}
+          >
+            {resource.name}
+          </Text>
+        )}
+      </View>
+      {/* 日付セル */}
+      {days.map((day, dateIndex) => (
+        <DayCell
+          key={day.format('YYYY-MM-DD')}
+          resource={resource}
+          date={day}
+          dateIndex={dateIndex}
+          columnWidth={columnWidth}
+          eventHeight={resolvedEventHeight}
+          eventPosition={eventPosition}
+          eventsByResourceId={eventsByResourceId}
+          onPressCell={onPressCell}
+          onLongPressCell={onLongPressCell}
+          delayLongPressCell={delayLongPressCell}
+          onPressEvent={onPressEvent}
+          onLongPressEvent={onLongPressEvent}
+          delayLongPressEvent={delayLongPressEvent}
+          prioritizeCellInteraction={prioritizeCellInteraction}
+          eventTextStyle={eventTextStyle}
+          eventEllipsizeMode={eventEllipsizeMode}
+          allowFontScaling={allowFontScaling}
+          renderEventOverlay={renderEventOverlay}
+          cellContainerStyle={cellContainerStyle}
+        />
+      ))}
+    </View>
+  );
 
   return (
     <View style={[styles.panel, { width }]}>
@@ -355,7 +417,12 @@ export function WeekPanel({
         ))}
       </View>
 
-      {/* リソース行（縦スクロール） */}
+      {/* 固定リソース行（ScrollView 外） */}
+      {fixedResources.map((resource, index) =>
+        renderResourceRow(resource, index === 0)
+      )}
+
+      {/* スクロールリソース行 */}
       <ScrollView
         showsVerticalScrollIndicator={false}
         refreshControl={
@@ -365,52 +432,12 @@ export function WeekPanel({
           />
         }
       >
-        {resources.map((resource, index) => (
-          <View
-            key={resource.id}
-            style={[styles.resourceRow, index === 0 && styles.resourceRowFirst]}
-          >
-            {/* リソース名セル */}
-            <View style={[styles.resourceNameCell, { width: columnWidth }]}>
-              {renderResourceNameLabel ? (
-                renderResourceNameLabel(resource)
-              ) : (
-                <Text
-                  style={styles.resourceNameText}
-                  numberOfLines={2}
-                  allowFontScaling={allowFontScaling}
-                >
-                  {resource.name}
-                </Text>
-              )}
-            </View>
-            {/* 日付セル */}
-            {days.map((day, dateIndex) => (
-              <DayCell
-                key={day.format('YYYY-MM-DD')}
-                resource={resource}
-                date={day}
-                dateIndex={dateIndex}
-                columnWidth={columnWidth}
-                eventHeight={resolvedEventHeight}
-                eventPosition={eventPosition}
-                eventsByResourceId={eventsByResourceId}
-                onPressCell={onPressCell}
-                onLongPressCell={onLongPressCell}
-                delayLongPressCell={delayLongPressCell}
-                onPressEvent={onPressEvent}
-                onLongPressEvent={onLongPressEvent}
-                delayLongPressEvent={delayLongPressEvent}
-                prioritizeCellInteraction={prioritizeCellInteraction}
-                eventTextStyle={eventTextStyle}
-                eventEllipsizeMode={eventEllipsizeMode}
-                allowFontScaling={allowFontScaling}
-                renderEventOverlay={renderEventOverlay}
-                cellContainerStyle={cellContainerStyle}
-              />
-            ))}
-          </View>
-        ))}
+        {scrollableResources.map((resource, index) =>
+          renderResourceRow(
+            resource,
+            fixedResources.length === 0 && index === 0
+          )
+        )}
         <View style={{ height: bottomSpacing }} />
       </ScrollView>
     </View>
@@ -430,6 +457,7 @@ const styles = StyleSheet.create({
   headerCell: {
     alignItems: 'center',
     justifyContent: 'center',
+    paddingVertical: 6,
     borderRightWidth: CELL_BORDER_WIDTH,
     borderRightColor: BORDER_COLOR,
   },

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
   type TextStyle,
+  type ViewStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
 import { useMemo, type ReactNode } from 'react';
@@ -37,6 +38,8 @@ export type WeekPanelProps = {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
+  dateCellContainerStyle?: (date: Date) => ViewStyle;
+  cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
 };
 
 type DayCellProps = {
@@ -58,6 +61,7 @@ type DayCellProps = {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
+  cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
 };
 
 function DayCell({
@@ -79,6 +83,7 @@ function DayCell({
   eventEllipsizeMode,
   allowFontScaling,
   renderEventOverlay,
+  cellContainerStyle,
 }: DayCellProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
 
@@ -138,7 +143,12 @@ function DayCell({
 
   const cellInner = (
     <>
-      <View style={styles.dayCellBackground} />
+      <View
+        style={[
+          styles.dayCellBackground,
+          cellContainerStyle?.(resource, date.toDate()),
+        ]}
+      />
       {cellEvents.map((event, rowIndex) => {
         if (typeof event === 'number') {
           return (
@@ -275,6 +285,8 @@ export function WeekPanel({
   eventEllipsizeMode,
   allowFontScaling,
   renderEventOverlay,
+  dateCellContainerStyle,
+  cellContainerStyle,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -312,7 +324,11 @@ export function WeekPanel({
         {days.map((day) => (
           <View
             key={day.format('YYYY-MM-DD')}
-            style={[styles.headerCell, { width: columnWidth }]}
+            style={[
+              styles.headerCell,
+              { width: columnWidth },
+              dateCellContainerStyle?.(day.toDate()),
+            ]}
           >
             <Text style={styles.headerDayOfWeekText}>{day.format('ddd')}</Text>
             <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
@@ -359,6 +375,7 @@ export function WeekPanel({
                 eventEllipsizeMode={eventEllipsizeMode}
                 allowFontScaling={allowFontScaling}
                 renderEventOverlay={renderEventOverlay}
+                cellContainerStyle={cellContainerStyle}
               />
             ))}
           </View>

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -1,0 +1,116 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import dayjs from 'dayjs';
+import type { CalendarResource } from '../../types/resources-calendar';
+
+export const CELL_BORDER_WIDTH = 0.5;
+export const BORDER_COLOR = 'lightslategrey';
+
+export type WeekPanelProps = {
+  weekKey: string;
+  width: number;
+  resources: CalendarResource[];
+};
+
+export function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
+  const columnWidth = width / 8;
+  const startDjs = dayjs(weekKey);
+  const days = Array.from({ length: 7 }, (_, i) => startDjs.add(i, 'day'));
+
+  return (
+    <View style={[styles.panel, { width }]}>
+      {/* ヘッダー行（固定） */}
+      <View style={styles.headerRow}>
+        <View
+          style={[
+            styles.headerCell,
+            styles.resourceNameHeaderCell,
+            { width: columnWidth },
+          ]}
+        />
+        {days.map((day) => (
+          <View
+            key={day.format('YYYY-MM-DD')}
+            style={[styles.headerCell, { width: columnWidth }]}
+          >
+            <Text style={styles.headerDayOfWeekText}>{day.format('ddd')}</Text>
+            <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
+          </View>
+        ))}
+      </View>
+
+      {/* リソース行（縦スクロール） */}
+      <ScrollView showsVerticalScrollIndicator={false}>
+        {resources.map((resource) => (
+          <View key={resource.id} style={styles.resourceRow}>
+            <View style={[styles.resourceNameCell, { width: columnWidth }]}>
+              <Text style={styles.resourceNameText} numberOfLines={2}>
+                {resource.name}
+              </Text>
+            </View>
+            {days.map((day) => (
+              <View
+                key={day.format('YYYY-MM-DD')}
+                style={[styles.dayCell, { width: columnWidth }]}
+              />
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    flex: 1,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    backgroundColor: 'white',
+    borderBottomWidth: CELL_BORDER_WIDTH,
+    borderBottomColor: BORDER_COLOR,
+  },
+  headerCell: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 6,
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+  },
+  resourceNameHeaderCell: {
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+  },
+  headerDayOfWeekText: {
+    fontSize: 11,
+    color: '#666',
+  },
+  headerDateText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#222',
+  },
+  resourceRow: {
+    flexDirection: 'row',
+    minHeight: 48,
+    borderBottomWidth: CELL_BORDER_WIDTH,
+    borderBottomColor: BORDER_COLOR,
+    backgroundColor: 'white',
+  },
+  resourceNameCell: {
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+    backgroundColor: '#fafafa',
+  },
+  resourceNameText: {
+    fontSize: 11,
+    color: '#333',
+  },
+  dayCell: {
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+    minHeight: 48,
+  },
+});

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -8,7 +8,7 @@ import {
   type TextStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import type {
   CalendarResource,
   CalendarEvent,
@@ -36,6 +36,7 @@ export type WeekPanelProps = {
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
 };
 
 type DayCellProps = {
@@ -56,6 +57,7 @@ type DayCellProps = {
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
 };
 
 function DayCell({
@@ -76,6 +78,7 @@ function DayCell({
   eventTextStyle,
   eventEllipsizeMode,
   allowFontScaling,
+  renderEventOverlay,
 }: DayCellProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
 
@@ -167,6 +170,12 @@ function DayCell({
           rowNum: rowIndex + 1,
         });
 
+        const eventOverlayNode = renderEventOverlay?.(event);
+        const showEventOverlay =
+          renderEventOverlay != null &&
+          eventOverlayNode != null &&
+          eventOverlayNode !== false;
+
         return (
           <View
             key={event.id}
@@ -213,6 +222,11 @@ function DayCell({
                 {event.title}
               </Text>
             </TouchableOpacity>
+            {showEventOverlay ? (
+              <View style={styles.eventOverlayHost} pointerEvents="box-none">
+                {eventOverlayNode}
+              </View>
+            ) : null}
           </View>
         );
       })}
@@ -260,6 +274,7 @@ export function WeekPanel({
   eventTextStyle,
   eventEllipsizeMode,
   allowFontScaling,
+  renderEventOverlay,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -343,6 +358,7 @@ export function WeekPanel({
                 eventTextStyle={eventTextStyle}
                 eventEllipsizeMode={eventEllipsizeMode}
                 allowFontScaling={allowFontScaling}
+                renderEventOverlay={renderEventOverlay}
               />
             ))}
           </View>
@@ -451,5 +467,9 @@ const styles = StyleSheet.create({
   },
   eventTitle: {
     fontSize: 11,
+  },
+  eventOverlayHost: {
+    ...StyleSheet.absoluteFillObject,
+    pointerEvents: 'box-none' as const,
   },
 });

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -288,7 +288,7 @@ const styles = StyleSheet.create({
   },
   resourceRow: {
     flexDirection: 'row',
-    minHeight: 48,
+    minHeight: 30,
     borderBottomWidth: CELL_BORDER_WIDTH,
     borderBottomColor: BORDER_COLOR,
     backgroundColor: 'white',
@@ -311,7 +311,7 @@ const styles = StyleSheet.create({
   dayCell: {
     borderRightWidth: CELL_BORDER_WIDTH,
     borderRightColor: BORDER_COLOR,
-    minHeight: 48,
+    minHeight: 30,
     paddingBottom: EVENT_GAP,
     position: 'relative',
   },

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -45,6 +45,7 @@ export type WeekPanelProps = {
   renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
   onRefresh?: () => void;
   refreshing?: boolean;
+  bottomSpacing?: number;
 };
 
 type DayCellProps = {
@@ -296,6 +297,7 @@ export function WeekPanel({
   renderResourceNameLabel,
   onRefresh,
   refreshing,
+  bottomSpacing,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -409,6 +411,7 @@ export function WeekPanel({
             ))}
           </View>
         ))}
+        <View style={{ height: bottomSpacing }} />
       </ScrollView>
     </View>
   );

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -25,6 +25,9 @@ export type WeekPanelProps = {
   resources: CalendarResource[];
   events: CalendarEvent[];
   eventHeight?: number;
+  onPressEvent?: (event: CalendarEvent) => void;
+  onLongPressEvent?: (event: CalendarEvent) => void;
+  delayLongPressEvent?: number;
 };
 
 type DayCellProps = {
@@ -35,6 +38,9 @@ type DayCellProps = {
   eventHeight: number;
   eventPosition: ResourcesCalendarEventPosition;
   eventsByResourceId: Map<string, CalendarEvent[]>;
+  onPressEvent?: (event: CalendarEvent) => void;
+  onLongPressEvent?: (event: CalendarEvent) => void;
+  delayLongPressEvent?: number;
 };
 
 function DayCell({
@@ -45,6 +51,9 @@ function DayCell({
   eventHeight,
   eventPosition,
   eventsByResourceId,
+  onPressEvent,
+  onLongPressEvent,
+  delayLongPressEvent,
 }: DayCellProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
 
@@ -157,6 +166,9 @@ function DayCell({
                 isPrevDateEvent && styles.prevDateEventInner,
               ]}
               activeOpacity={0.8}
+              onPress={() => onPressEvent?.(event)}
+              onLongPress={() => onLongPressEvent?.(event)}
+              delayLongPress={delayLongPressEvent}
             >
               <Text
                 numberOfLines={1}
@@ -178,6 +190,9 @@ export function WeekPanel({
   resources,
   events,
   eventHeight,
+  onPressEvent,
+  onLongPressEvent,
+  delayLongPressEvent,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -247,6 +262,9 @@ export function WeekPanel({
                 eventHeight={resolvedEventHeight}
                 eventPosition={eventPosition}
                 eventsByResourceId={eventsByResourceId}
+                onPressEvent={onPressEvent}
+                onLongPressEvent={onLongPressEvent}
+                delayLongPressEvent={delayLongPressEvent}
               />
             ))}
           </View>

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -111,12 +111,9 @@ function DayCell({
         const rawStartDjs = dayjs(event.start);
         const startDjs = dateIndex === 0 ? date : rawStartDjs;
         const endDjs = dayjs(event.end);
-        const diffDaysRaw = endDjs
+        const diffDays = endDjs
           .startOf('day')
           .diff(startDjs.startOf('day'), 'day');
-        // 週の残り日数に収める
-        const maxDiff = 6 - dateIndex;
-        const diffDays = Math.min(diffDaysRaw, maxDiff);
         const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(date);
 
         let width =

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, type ReactNode } from 'react';
 import {
   Platform,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -42,6 +43,8 @@ export type WeekPanelProps = {
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
   renderDateLabel?: (date: Date) => React.JSX.Element;
   renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
+  onRefresh?: () => void;
+  refreshing?: boolean;
 };
 
 type DayCellProps = {
@@ -291,6 +294,8 @@ export function WeekPanel({
   cellContainerStyle,
   renderDateLabel,
   renderResourceNameLabel,
+  onRefresh,
+  refreshing,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -349,7 +354,15 @@ export function WeekPanel({
       </View>
 
       {/* リソース行（縦スクロール） */}
-      <ScrollView showsVerticalScrollIndicator={false}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing ?? false}
+            onRefresh={onRefresh}
+          />
+        }
+      >
         {resources.map((resource, index) => (
           <View
             key={resource.id}

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -330,7 +330,6 @@ export function WeekPanel({
     [resources, resolvedFixedRowCount]
   );
 
-  // パネル全体で1インスタンス（resourceIdで区別される）
   const eventPosition = new ResourcesCalendarEventPosition();
 
   const renderResourceRow = (
@@ -341,7 +340,6 @@ export function WeekPanel({
       key={resource.id}
       style={[styles.resourceRow, showTopBorder && styles.resourceRowFirst]}
     >
-      {/* リソース名セル */}
       <View style={[styles.resourceNameCell, { width: columnWidth }]}>
         {renderResourceNameLabel ? (
           renderResourceNameLabel(resource)
@@ -355,7 +353,6 @@ export function WeekPanel({
           </Text>
         )}
       </View>
-      {/* 日付セル */}
       {days.map((day, dateIndex) => (
         <DayCell
           key={day.format('YYYY-MM-DD')}
@@ -385,7 +382,6 @@ export function WeekPanel({
 
   return (
     <View style={[styles.panel, { width }]}>
-      {/* ヘッダー行（固定） */}
       <View style={styles.headerRow}>
         <View
           style={[
@@ -417,12 +413,10 @@ export function WeekPanel({
         ))}
       </View>
 
-      {/* 固定リソース行（ScrollView 外） */}
       {fixedResources.map((resource, index) =>
         renderResourceRow(resource, index === 0)
       )}
 
-      {/* スクロールリソース行 */}
       <ScrollView
         showsVerticalScrollIndicator={false}
         refreshControl={

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -31,6 +31,7 @@ export type WeekPanelProps = {
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
+  prioritizeCellInteraction?: boolean;
 };
 
 type DayCellProps = {
@@ -47,6 +48,7 @@ type DayCellProps = {
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
+  prioritizeCellInteraction?: boolean;
 };
 
 function DayCell({
@@ -63,6 +65,7 @@ function DayCell({
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
+  prioritizeCellInteraction,
 }: DayCellProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
 
@@ -111,14 +114,17 @@ function DayCell({
     }
   }
 
-  return (
-    <TouchableOpacity
-      activeOpacity={1}
-      style={[styles.dayCell, { width: columnWidth, zIndex: 7 - dateIndex }]}
-      onPress={() => onPressCell?.(resource, date.toDate())}
-      onLongPress={() => onLongPressCell?.(resource, date.toDate())}
-      delayLongPress={delayLongPressCell}
-    >
+  const showPrioritizedCellOverlay =
+    prioritizeCellInteraction === true &&
+    (onPressCell != null || onLongPressCell != null);
+
+  const cellWrapperStyle = [
+    styles.dayCell,
+    { width: columnWidth, zIndex: 7 - dateIndex },
+  ];
+
+  const cellInner = (
+    <>
       <View style={styles.dayCellBackground} />
       {cellEvents.map((event, rowIndex) => {
         if (typeof event === 'number') {
@@ -154,6 +160,7 @@ function DayCell({
         return (
           <View
             key={event.id}
+            pointerEvents={showPrioritizedCellOverlay ? 'none' : 'auto'}
             style={[
               styles.eventOuter,
               { width, height: eventHeight },
@@ -193,6 +200,30 @@ function DayCell({
           </View>
         );
       })}
+    </>
+  );
+
+  return showPrioritizedCellOverlay ? (
+    <View style={cellWrapperStyle}>
+      {cellInner}
+      <TouchableOpacity
+        accessible={false}
+        style={styles.cellInteractionOverlay}
+        activeOpacity={1}
+        onPress={() => onPressCell?.(resource, date.toDate())}
+        onLongPress={() => onLongPressCell?.(resource, date.toDate())}
+        delayLongPress={delayLongPressCell}
+      />
+    </View>
+  ) : (
+    <TouchableOpacity
+      activeOpacity={1}
+      style={cellWrapperStyle}
+      onPress={() => onPressCell?.(resource, date.toDate())}
+      onLongPress={() => onLongPressCell?.(resource, date.toDate())}
+      delayLongPress={delayLongPressCell}
+    >
+      {cellInner}
     </TouchableOpacity>
   );
 }
@@ -209,6 +240,7 @@ export function WeekPanel({
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
+  prioritizeCellInteraction,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -284,6 +316,7 @@ export function WeekPanel({
                 onPressEvent={onPressEvent}
                 onLongPressEvent={onLongPressEvent}
                 delayLongPressEvent={delayLongPressEvent}
+                prioritizeCellInteraction={prioritizeCellInteraction}
               />
             ))}
           </View>
@@ -354,6 +387,15 @@ const styles = StyleSheet.create({
   },
   dayCellBackground: {
     ...StyleSheet.absoluteFillObject,
+  },
+  cellInteractionOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1000,
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      android: { elevation: 12 },
+      default: {},
+    }),
   },
   eventOuter: {
     position: 'relative',

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  type TextStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
@@ -32,6 +33,9 @@ export type WeekPanelProps = {
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
   prioritizeCellInteraction?: boolean;
+  eventTextStyle?: (event: CalendarEvent) => TextStyle;
+  eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  allowFontScaling?: boolean;
 };
 
 type DayCellProps = {
@@ -49,6 +53,9 @@ type DayCellProps = {
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
   prioritizeCellInteraction?: boolean;
+  eventTextStyle?: (event: CalendarEvent) => TextStyle;
+  eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  allowFontScaling?: boolean;
 };
 
 function DayCell({
@@ -66,6 +73,9 @@ function DayCell({
   onLongPressEvent,
   delayLongPressEvent,
   prioritizeCellInteraction,
+  eventTextStyle,
+  eventEllipsizeMode,
+  allowFontScaling,
 }: DayCellProps) {
   const resourceEvents = eventsByResourceId.get(resource.id) ?? [];
 
@@ -192,7 +202,13 @@ function DayCell({
             >
               <Text
                 numberOfLines={1}
-                style={[styles.eventTitle, { color: event.color }]}
+                ellipsizeMode={eventEllipsizeMode ?? 'tail'}
+                allowFontScaling={allowFontScaling}
+                style={[
+                  styles.eventTitle,
+                  { color: event.color },
+                  eventTextStyle?.(event),
+                ]}
               >
                 {event.title}
               </Text>
@@ -241,6 +257,9 @@ export function WeekPanel({
   onLongPressEvent,
   delayLongPressEvent,
   prioritizeCellInteraction,
+  eventTextStyle,
+  eventEllipsizeMode,
+  allowFontScaling,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -295,7 +314,11 @@ export function WeekPanel({
           >
             {/* リソース名セル */}
             <View style={[styles.resourceNameCell, { width: columnWidth }]}>
-              <Text style={styles.resourceNameText} numberOfLines={2}>
+              <Text
+                style={styles.resourceNameText}
+                numberOfLines={2}
+                allowFontScaling={allowFontScaling}
+              >
                 {resource.name}
               </Text>
             </View>
@@ -317,6 +340,9 @@ export function WeekPanel({
                 onLongPressEvent={onLongPressEvent}
                 delayLongPressEvent={delayLongPressEvent}
                 prioritizeCellInteraction={prioritizeCellInteraction}
+                eventTextStyle={eventTextStyle}
+                eventEllipsizeMode={eventEllipsizeMode}
+                allowFontScaling={allowFontScaling}
               />
             ))}
           </View>

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -40,8 +40,11 @@ export function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
 
       {/* リソース行（縦スクロール） */}
       <ScrollView showsVerticalScrollIndicator={false}>
-        {resources.map((resource) => (
-          <View key={resource.id} style={styles.resourceRow}>
+        {resources.map((resource, index) => (
+          <View
+            key={resource.id}
+            style={[styles.resourceRow, index === 0 && styles.resourceRowFirst]}
+          >
             <View style={[styles.resourceNameCell, { width: columnWidth }]}>
               <Text style={styles.resourceNameText} numberOfLines={2}>
                 {resource.name}
@@ -96,6 +99,10 @@ const styles = StyleSheet.create({
     borderBottomWidth: CELL_BORDER_WIDTH,
     borderBottomColor: BORDER_COLOR,
     backgroundColor: 'white',
+  },
+  resourceRowFirst: {
+    borderTopWidth: CELL_BORDER_WIDTH,
+    borderTopColor: BORDER_COLOR,
   },
   resourceNameCell: {
     justifyContent: 'center',

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -25,6 +25,9 @@ export type WeekPanelProps = {
   resources: CalendarResource[];
   events: CalendarEvent[];
   eventHeight?: number;
+  onPressCell?: (resource: CalendarResource, date: Date) => void;
+  onLongPressCell?: (resource: CalendarResource, date: Date) => void;
+  delayLongPressCell?: number;
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
@@ -38,6 +41,9 @@ type DayCellProps = {
   eventHeight: number;
   eventPosition: ResourcesCalendarEventPosition;
   eventsByResourceId: Map<string, CalendarEvent[]>;
+  onPressCell?: (resource: CalendarResource, date: Date) => void;
+  onLongPressCell?: (resource: CalendarResource, date: Date) => void;
+  delayLongPressCell?: number;
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
@@ -51,6 +57,9 @@ function DayCell({
   eventHeight,
   eventPosition,
   eventsByResourceId,
+  onPressCell,
+  onLongPressCell,
+  delayLongPressCell,
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
@@ -103,8 +112,12 @@ function DayCell({
   }
 
   return (
-    <View
+    <TouchableOpacity
+      activeOpacity={1}
       style={[styles.dayCell, { width: columnWidth, zIndex: 7 - dateIndex }]}
+      onPress={() => onPressCell?.(resource, date.toDate())}
+      onLongPress={() => onLongPressCell?.(resource, date.toDate())}
+      delayLongPress={delayLongPressCell}
     >
       <View style={styles.dayCellBackground} />
       {cellEvents.map((event, rowIndex) => {
@@ -180,7 +193,7 @@ function DayCell({
           </View>
         );
       })}
-    </View>
+    </TouchableOpacity>
   );
 }
 
@@ -190,6 +203,9 @@ export function WeekPanel({
   resources,
   events,
   eventHeight,
+  onPressCell,
+  onLongPressCell,
+  delayLongPressCell,
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
@@ -262,6 +278,9 @@ export function WeekPanel({
                 eventHeight={resolvedEventHeight}
                 eventPosition={eventPosition}
                 eventsByResourceId={eventsByResourceId}
+                onPressCell={onPressCell}
+                onLongPressCell={onLongPressCell}
+                delayLongPressCell={delayLongPressCell}
                 onPressEvent={onPressEvent}
                 onLongPressEvent={onLongPressEvent}
                 delayLongPressEvent={delayLongPressEvent}

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -1,3 +1,4 @@
+import React, { useMemo, type ReactNode } from 'react';
 import {
   Platform,
   ScrollView,
@@ -9,7 +10,6 @@ import {
   type ViewStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
-import { useMemo, type ReactNode } from 'react';
 import type {
   CalendarResource,
   CalendarEvent,
@@ -40,6 +40,8 @@ export type WeekPanelProps = {
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   dateCellContainerStyle?: (date: Date) => ViewStyle;
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
+  renderDateLabel?: (date: Date) => React.JSX.Element;
+  renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
 };
 
 type DayCellProps = {
@@ -287,6 +289,8 @@ export function WeekPanel({
   renderEventOverlay,
   dateCellContainerStyle,
   cellContainerStyle,
+  renderDateLabel,
+  renderResourceNameLabel,
 }: WeekPanelProps) {
   const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
@@ -330,8 +334,16 @@ export function WeekPanel({
               dateCellContainerStyle?.(day.toDate()),
             ]}
           >
-            <Text style={styles.headerDayOfWeekText}>{day.format('ddd')}</Text>
-            <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
+            {renderDateLabel ? (
+              renderDateLabel(day.toDate())
+            ) : (
+              <>
+                <Text style={styles.headerDayOfWeekText}>
+                  {day.format('ddd')}
+                </Text>
+                <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
+              </>
+            )}
           </View>
         ))}
       </View>
@@ -345,13 +357,17 @@ export function WeekPanel({
           >
             {/* リソース名セル */}
             <View style={[styles.resourceNameCell, { width: columnWidth }]}>
-              <Text
-                style={styles.resourceNameText}
-                numberOfLines={2}
-                allowFontScaling={allowFontScaling}
-              >
-                {resource.name}
-              </Text>
+              {renderResourceNameLabel ? (
+                renderResourceNameLabel(resource)
+              ) : (
+                <Text
+                  style={styles.resourceNameText}
+                  numberOfLines={2}
+                  allowFontScaling={allowFontScaling}
+                >
+                  {resource.name}
+                </Text>
+              )}
             </View>
             {/* 日付セル */}
             {days.map((day, dateIndex) => (
@@ -398,7 +414,6 @@ const styles = StyleSheet.create({
   headerCell: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: 6,
     borderRightWidth: CELL_BORDER_WIDTH,
     borderRightColor: BORDER_COLOR,
   },

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -157,6 +157,7 @@ function DayCell({
                     borderRadius: event.borderRadius,
                   }),
                 },
+                isPrevDateEvent && styles.prevDateEventInner,
               ]}
               activeOpacity={0.8}
             >
@@ -327,6 +328,8 @@ const styles = StyleSheet.create({
   },
   prevDateEvent: {
     marginLeft: -1,
+  },
+  prevDateEventInner: {
     borderTopStartRadius: 0,
     borderBottomStartRadius: 0,
   },

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,5 +1,6 @@
 import {
   FlatList,
+  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -8,13 +9,17 @@ import {
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
+import type { CalendarResource } from '../../types/resources-calendar';
 
 const HALF_PANEL_LENGTH = 120;
+const CELL_BORDER_WIDTH = 0.5;
+const BORDER_COLOR = 'lightslategrey';
 
 type WeekResourcesCalendarProps = {
   defaultDate: Date;
   weekStartsOn?: WeekStartsOn;
   onChangeDate?: (date: Date) => void;
+  resources: CalendarResource[];
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -32,17 +37,54 @@ function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
 type WeekPanelProps = {
   weekKey: string;
   width: number;
+  resources: CalendarResource[];
 };
 
-function WeekPanel({ weekKey, width }: WeekPanelProps) {
+function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
+  const columnWidth = width / 8;
   const startDjs = dayjs(weekKey);
-  const endDjs = startDjs.add(6, 'day');
+  const days = Array.from({ length: 7 }, (_, i) => startDjs.add(i, 'day'));
 
   return (
     <View style={[styles.panel, { width }]}>
-      <Text style={styles.dateText}>{startDjs.format('YYYY/MM/DD')}</Text>
-      <Text style={styles.separator}>〜</Text>
-      <Text style={styles.dateText}>{endDjs.format('YYYY/MM/DD')}</Text>
+      {/* ヘッダー行（固定） */}
+      <View style={styles.headerRow}>
+        <View
+          style={[
+            styles.headerCell,
+            styles.resourceNameHeaderCell,
+            { width: columnWidth },
+          ]}
+        />
+        {days.map((day) => (
+          <View
+            key={day.format('YYYY-MM-DD')}
+            style={[styles.headerCell, { width: columnWidth }]}
+          >
+            <Text style={styles.headerDayOfWeekText}>{day.format('ddd')}</Text>
+            <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
+          </View>
+        ))}
+      </View>
+
+      {/* リソース行（縦スクロール） */}
+      <ScrollView showsVerticalScrollIndicator={false}>
+        {resources.map((resource) => (
+          <View key={resource.id} style={styles.resourceRow}>
+            <View style={[styles.resourceNameCell, { width: columnWidth }]}>
+              <Text style={styles.resourceNameText} numberOfLines={2}>
+                {resource.name}
+              </Text>
+            </View>
+            {days.map((day) => (
+              <View
+                key={day.format('YYYY-MM-DD')}
+                style={[styles.dayCell, { width: columnWidth }]}
+              />
+            ))}
+          </View>
+        ))}
+      </ScrollView>
     </View>
   );
 }
@@ -51,6 +93,7 @@ export const WeekResourcesCalendar = ({
   defaultDate,
   weekStartsOn = 0,
   onChangeDate,
+  resources,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -91,7 +134,9 @@ export const WeekResourcesCalendar = ({
         offset: width * index,
         index,
       })}
-      renderItem={({ item }) => <WeekPanel weekKey={item} width={width} />}
+      renderItem={({ item }) => (
+        <WeekPanel weekKey={item} width={width} resources={resources} />
+      )}
       onMomentumScrollEnd={(e) => {
         const scrollX = e.nativeEvent.contentOffset.x;
         const newIndex = Math.round(scrollX / width);
@@ -112,18 +157,56 @@ export const WeekResourcesCalendar = ({
 };
 
 const styles = StyleSheet.create({
-  panel: {
-    flex: 1,
+  headerRow: {
     flexDirection: 'row',
+    backgroundColor: 'white',
+    borderBottomWidth: CELL_BORDER_WIDTH,
+    borderBottomColor: BORDER_COLOR,
+  },
+  headerCell: {
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 8,
+    paddingVertical: 6,
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
   },
-  dateText: {
-    fontSize: 16,
+  resourceNameHeaderCell: {
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
   },
-  separator: {
-    fontSize: 14,
-    color: '#888',
+  headerDayOfWeekText: {
+    fontSize: 11,
+    color: '#666',
+  },
+  headerDateText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#222',
+  },
+  resourceRow: {
+    flexDirection: 'row',
+    minHeight: 48,
+    borderBottomWidth: CELL_BORDER_WIDTH,
+    borderBottomColor: BORDER_COLOR,
+    backgroundColor: 'white',
+  },
+  resourceNameCell: {
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+    backgroundColor: '#fafafa',
+  },
+  resourceNameText: {
+    fontSize: 11,
+    color: '#333',
+  },
+  dayCell: {
+    borderRightWidth: CELL_BORDER_WIDTH,
+    borderRightColor: BORDER_COLOR,
+    minHeight: 48,
+  },
+  panel: {
+    flex: 1,
   },
 });

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,6 +1,6 @@
 import { FlatList, useWindowDimensions, type TextStyle } from 'react-native';
 import dayjs from 'dayjs';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
 import type {
   CalendarResource,
@@ -32,6 +32,7 @@ type WeekResourcesCalendarProps = {
   eventTextStyle?: (event: CalendarEvent) => TextStyle;
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
+  renderEventOverlay?: (event: CalendarEvent) => ReactNode;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -63,6 +64,7 @@ export const WeekResourcesCalendar = ({
   eventTextStyle,
   eventEllipsizeMode,
   allowFontScaling,
+  renderEventOverlay,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -120,6 +122,7 @@ export const WeekResourcesCalendar = ({
           eventTextStyle={eventTextStyle}
           eventEllipsizeMode={eventEllipsizeMode}
           allowFontScaling={allowFontScaling}
+          renderEventOverlay={renderEventOverlay}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,4 +1,4 @@
-import { FlatList, useWindowDimensions } from 'react-native';
+import { FlatList, useWindowDimensions, type TextStyle } from 'react-native';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
@@ -29,6 +29,9 @@ type WeekResourcesCalendarProps = {
    * Event taps are disabled while this is on (overlay captures the gesture).
    */
   prioritizeCellInteraction?: boolean;
+  eventTextStyle?: (event: CalendarEvent) => TextStyle;
+  eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  allowFontScaling?: boolean;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -57,6 +60,9 @@ export const WeekResourcesCalendar = ({
   onLongPressEvent,
   delayLongPressEvent,
   prioritizeCellInteraction,
+  eventTextStyle,
+  eventEllipsizeMode,
+  allowFontScaling,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -111,6 +117,9 @@ export const WeekResourcesCalendar = ({
           onLongPressEvent={onLongPressEvent}
           delayLongPressEvent={delayLongPressEvent}
           prioritizeCellInteraction={prioritizeCellInteraction}
+          eventTextStyle={eventTextStyle}
+          eventEllipsizeMode={eventEllipsizeMode}
+          allowFontScaling={allowFontScaling}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -45,6 +45,7 @@ type WeekResourcesCalendarProps = {
   onRefresh?: () => void;
   refreshing?: boolean;
   bottomSpacing?: number;
+  fixedRowCount?: number;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -84,6 +85,7 @@ export const WeekResourcesCalendar = ({
   onRefresh,
   refreshing,
   bottomSpacing,
+  fixedRowCount,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -149,6 +151,7 @@ export const WeekResourcesCalendar = ({
           onRefresh={onRefresh}
           refreshing={refreshing}
           bottomSpacing={bottomSpacing}
+          fixedRowCount={fixedRowCount}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -23,6 +23,12 @@ type WeekResourcesCalendarProps = {
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
+  /**
+   * When true, a transparent layer is placed above events in each cell so
+   * `onPressCell` / `onLongPressCell` receive touches for the full cell area.
+   * Event taps are disabled while this is on (overlay captures the gesture).
+   */
+  prioritizeCellInteraction?: boolean;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -50,6 +56,7 @@ export const WeekResourcesCalendar = ({
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
+  prioritizeCellInteraction,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -103,6 +110,7 @@ export const WeekResourcesCalendar = ({
           onPressEvent={onPressEvent}
           onLongPressEvent={onLongPressEvent}
           delayLongPressEvent={delayLongPressEvent}
+          prioritizeCellInteraction={prioritizeCellInteraction}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -2,7 +2,10 @@ import { FlatList, useWindowDimensions } from 'react-native';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
-import type { CalendarResource } from '../../types/resources-calendar';
+import type {
+  CalendarResource,
+  CalendarEvent,
+} from '../../types/resources-calendar';
 import { WeekPanel } from './WeekPanel';
 
 const HALF_PANEL_LENGTH = 120;
@@ -12,6 +15,8 @@ type WeekResourcesCalendarProps = {
   weekStartsOn?: WeekStartsOn;
   onChangeDate?: (date: Date) => void;
   resources: CalendarResource[];
+  events: CalendarEvent[];
+  eventHeight?: number;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -31,6 +36,8 @@ export const WeekResourcesCalendar = ({
   weekStartsOn = 0,
   onChangeDate,
   resources,
+  events,
+  eventHeight,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -72,7 +79,13 @@ export const WeekResourcesCalendar = ({
         index,
       })}
       renderItem={({ item }) => (
-        <WeekPanel weekKey={item} width={width} resources={resources} />
+        <WeekPanel
+          weekKey={item}
+          width={width}
+          resources={resources}
+          events={events}
+          eventHeight={eventHeight}
+        />
       )}
       onMomentumScrollEnd={(e) => {
         const scrollX = e.nativeEvent.contentOffset.x;

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,0 +1,129 @@
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import dayjs from 'dayjs';
+import { useState } from 'react';
+import type { WeekStartsOn } from '../../types/month-calendar';
+
+const HALF_PANEL_LENGTH = 120;
+
+type WeekResourcesCalendarProps = {
+  defaultDate: Date;
+  weekStartsOn?: WeekStartsOn;
+  onChangeDate?: (date: Date) => void;
+};
+
+function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
+  const djs = dayjs(date);
+  if (weekStartsOn === 0) {
+    return djs.startOf('week');
+  }
+  const day = djs.day();
+  if (day === 0) {
+    return djs.subtract(6, 'day').startOf('day');
+  }
+  return djs.subtract(day - 1, 'day').startOf('day');
+}
+
+type WeekPanelProps = {
+  weekKey: string;
+  width: number;
+};
+
+function WeekPanel({ weekKey, width }: WeekPanelProps) {
+  const startDjs = dayjs(weekKey);
+  const endDjs = startDjs.add(6, 'day');
+
+  return (
+    <View style={[styles.panel, { width }]}>
+      <Text style={styles.dateText}>{startDjs.format('YYYY/MM/DD')}</Text>
+      <Text style={styles.separator}>〜</Text>
+      <Text style={styles.dateText}>{endDjs.format('YYYY/MM/DD')}</Text>
+    </View>
+  );
+}
+
+export const WeekResourcesCalendar = ({
+  defaultDate,
+  weekStartsOn = 0,
+  onChangeDate,
+}: WeekResourcesCalendarProps) => {
+  const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
+  const { width } = useWindowDimensions();
+
+  const startOfDefaultWeek = getWeekStart(defaultDate, weekStartsOn);
+
+  const prevPanels: string[] = Array.from(
+    { length: HALF_PANEL_LENGTH },
+    (_, i) => {
+      return startOfDefaultWeek
+        .subtract(HALF_PANEL_LENGTH - i, 'week')
+        .format('YYYY-MM-DD');
+    }
+  );
+
+  const nextPanels: string[] = Array.from(
+    { length: HALF_PANEL_LENGTH },
+    (_, i) => {
+      return startOfDefaultWeek.add(i + 1, 'week').format('YYYY-MM-DD');
+    }
+  );
+
+  const panels: string[] = [
+    ...prevPanels,
+    startOfDefaultWeek.format('YYYY-MM-DD'),
+    ...nextPanels,
+  ];
+
+  return (
+    <FlatList
+      horizontal
+      pagingEnabled
+      data={panels}
+      keyExtractor={(item) => item}
+      initialScrollIndex={HALF_PANEL_LENGTH}
+      getItemLayout={(_data, index) => ({
+        length: width,
+        offset: width * index,
+        index,
+      })}
+      renderItem={({ item }) => <WeekPanel weekKey={item} width={width} />}
+      onMomentumScrollEnd={(e) => {
+        const scrollX = e.nativeEvent.contentOffset.x;
+        const newIndex = Math.round(scrollX / width);
+        setActiveIndex(newIndex);
+        const weekKey = panels[newIndex];
+        if (weekKey) {
+          onChangeDate?.(dayjs(weekKey).toDate());
+        }
+      }}
+      showsHorizontalScrollIndicator={false}
+      decelerationRate="fast"
+      windowSize={5}
+      initialNumToRender={5}
+      maxToRenderPerBatch={5}
+      removeClippedSubviews={false}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  panel: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  dateText: {
+    fontSize: 16,
+  },
+  separator: {
+    fontSize: 14,
+    color: '#888',
+  },
+});

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,3 +1,4 @@
+import React, { useState, type ReactNode } from 'react';
 import {
   FlatList,
   useWindowDimensions,
@@ -5,7 +6,6 @@ import {
   type ViewStyle,
 } from 'react-native';
 import dayjs from 'dayjs';
-import { useState, type ReactNode } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
 import type {
   CalendarResource,
@@ -40,6 +40,8 @@ type WeekResourcesCalendarProps = {
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
   dateCellContainerStyle?: (date: Date) => ViewStyle;
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
+  renderDateLabel?: (date: Date) => React.JSX.Element;
+  renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -74,6 +76,8 @@ export const WeekResourcesCalendar = ({
   renderEventOverlay,
   dateCellContainerStyle,
   cellContainerStyle,
+  renderDateLabel,
+  renderResourceNameLabel,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -134,6 +138,8 @@ export const WeekResourcesCalendar = ({
           renderEventOverlay={renderEventOverlay}
           dateCellContainerStyle={dateCellContainerStyle}
           cellContainerStyle={cellContainerStyle}
+          renderDateLabel={renderDateLabel}
+          renderResourceNameLabel={renderResourceNameLabel}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -17,6 +17,9 @@ type WeekResourcesCalendarProps = {
   resources: CalendarResource[];
   events: CalendarEvent[];
   eventHeight?: number;
+  onPressCell?: (resource: CalendarResource, date: Date) => void;
+  onLongPressCell?: (resource: CalendarResource, date: Date) => void;
+  delayLongPressCell?: number;
   onPressEvent?: (event: CalendarEvent) => void;
   onLongPressEvent?: (event: CalendarEvent) => void;
   delayLongPressEvent?: number;
@@ -41,6 +44,9 @@ export const WeekResourcesCalendar = ({
   resources,
   events,
   eventHeight,
+  onPressCell,
+  onLongPressCell,
+  delayLongPressCell,
   onPressEvent,
   onLongPressEvent,
   delayLongPressEvent,
@@ -91,6 +97,9 @@ export const WeekResourcesCalendar = ({
           resources={resources}
           events={events}
           eventHeight={eventHeight}
+          onPressCell={onPressCell}
+          onLongPressCell={onLongPressCell}
+          delayLongPressCell={delayLongPressCell}
           onPressEvent={onPressEvent}
           onLongPressEvent={onLongPressEvent}
           delayLongPressEvent={delayLongPressEvent}

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,19 +1,11 @@
-import {
-  FlatList,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-  useWindowDimensions,
-} from 'react-native';
+import { FlatList, useWindowDimensions } from 'react-native';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
 import type { CalendarResource } from '../../types/resources-calendar';
+import { WeekPanel } from './WeekPanel';
 
 const HALF_PANEL_LENGTH = 120;
-const CELL_BORDER_WIDTH = 0.5;
-const BORDER_COLOR = 'lightslategrey';
 
 type WeekResourcesCalendarProps = {
   defaultDate: Date;
@@ -32,61 +24,6 @@ function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
     return djs.subtract(6, 'day').startOf('day');
   }
   return djs.subtract(day - 1, 'day').startOf('day');
-}
-
-type WeekPanelProps = {
-  weekKey: string;
-  width: number;
-  resources: CalendarResource[];
-};
-
-function WeekPanel({ weekKey, width, resources }: WeekPanelProps) {
-  const columnWidth = width / 8;
-  const startDjs = dayjs(weekKey);
-  const days = Array.from({ length: 7 }, (_, i) => startDjs.add(i, 'day'));
-
-  return (
-    <View style={[styles.panel, { width }]}>
-      {/* ヘッダー行（固定） */}
-      <View style={styles.headerRow}>
-        <View
-          style={[
-            styles.headerCell,
-            styles.resourceNameHeaderCell,
-            { width: columnWidth },
-          ]}
-        />
-        {days.map((day) => (
-          <View
-            key={day.format('YYYY-MM-DD')}
-            style={[styles.headerCell, { width: columnWidth }]}
-          >
-            <Text style={styles.headerDayOfWeekText}>{day.format('ddd')}</Text>
-            <Text style={styles.headerDateText}>{day.format('M/D')}</Text>
-          </View>
-        ))}
-      </View>
-
-      {/* リソース行（縦スクロール） */}
-      <ScrollView showsVerticalScrollIndicator={false}>
-        {resources.map((resource) => (
-          <View key={resource.id} style={styles.resourceRow}>
-            <View style={[styles.resourceNameCell, { width: columnWidth }]}>
-              <Text style={styles.resourceNameText} numberOfLines={2}>
-                {resource.name}
-              </Text>
-            </View>
-            {days.map((day) => (
-              <View
-                key={day.format('YYYY-MM-DD')}
-                style={[styles.dayCell, { width: columnWidth }]}
-              />
-            ))}
-          </View>
-        ))}
-      </ScrollView>
-    </View>
-  );
 }
 
 export const WeekResourcesCalendar = ({
@@ -155,58 +92,3 @@ export const WeekResourcesCalendar = ({
     />
   );
 };
-
-const styles = StyleSheet.create({
-  headerRow: {
-    flexDirection: 'row',
-    backgroundColor: 'white',
-    borderBottomWidth: CELL_BORDER_WIDTH,
-    borderBottomColor: BORDER_COLOR,
-  },
-  headerCell: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 6,
-    borderRightWidth: CELL_BORDER_WIDTH,
-    borderRightColor: BORDER_COLOR,
-  },
-  resourceNameHeaderCell: {
-    borderRightWidth: CELL_BORDER_WIDTH,
-    borderRightColor: BORDER_COLOR,
-  },
-  headerDayOfWeekText: {
-    fontSize: 11,
-    color: '#666',
-  },
-  headerDateText: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: '#222',
-  },
-  resourceRow: {
-    flexDirection: 'row',
-    minHeight: 48,
-    borderBottomWidth: CELL_BORDER_WIDTH,
-    borderBottomColor: BORDER_COLOR,
-    backgroundColor: 'white',
-  },
-  resourceNameCell: {
-    justifyContent: 'center',
-    paddingHorizontal: 4,
-    borderRightWidth: CELL_BORDER_WIDTH,
-    borderRightColor: BORDER_COLOR,
-    backgroundColor: '#fafafa',
-  },
-  resourceNameText: {
-    fontSize: 11,
-    color: '#333',
-  },
-  dayCell: {
-    borderRightWidth: CELL_BORDER_WIDTH,
-    borderRightColor: BORDER_COLOR,
-    minHeight: 48,
-  },
-  panel: {
-    flex: 1,
-  },
-});

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,4 +1,9 @@
-import { FlatList, useWindowDimensions, type TextStyle } from 'react-native';
+import {
+  FlatList,
+  useWindowDimensions,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
 import dayjs from 'dayjs';
 import { useState, type ReactNode } from 'react';
 import type { WeekStartsOn } from '../../types/month-calendar';
@@ -33,6 +38,8 @@ type WeekResourcesCalendarProps = {
   eventEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
   allowFontScaling?: boolean;
   renderEventOverlay?: (event: CalendarEvent) => ReactNode;
+  dateCellContainerStyle?: (date: Date) => ViewStyle;
+  cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -65,6 +72,8 @@ export const WeekResourcesCalendar = ({
   eventEllipsizeMode,
   allowFontScaling,
   renderEventOverlay,
+  dateCellContainerStyle,
+  cellContainerStyle,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -123,6 +132,8 @@ export const WeekResourcesCalendar = ({
           eventEllipsizeMode={eventEllipsizeMode}
           allowFontScaling={allowFontScaling}
           renderEventOverlay={renderEventOverlay}
+          dateCellContainerStyle={dateCellContainerStyle}
+          cellContainerStyle={cellContainerStyle}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -17,6 +17,9 @@ type WeekResourcesCalendarProps = {
   resources: CalendarResource[];
   events: CalendarEvent[];
   eventHeight?: number;
+  onPressEvent?: (event: CalendarEvent) => void;
+  onLongPressEvent?: (event: CalendarEvent) => void;
+  delayLongPressEvent?: number;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -38,6 +41,9 @@ export const WeekResourcesCalendar = ({
   resources,
   events,
   eventHeight,
+  onPressEvent,
+  onLongPressEvent,
+  delayLongPressEvent,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -85,6 +91,9 @@ export const WeekResourcesCalendar = ({
           resources={resources}
           events={events}
           eventHeight={eventHeight}
+          onPressEvent={onPressEvent}
+          onLongPressEvent={onLongPressEvent}
+          delayLongPressEvent={delayLongPressEvent}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -44,6 +44,7 @@ type WeekResourcesCalendarProps = {
   renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
   onRefresh?: () => void;
   refreshing?: boolean;
+  bottomSpacing?: number;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -82,6 +83,7 @@ export const WeekResourcesCalendar = ({
   renderResourceNameLabel,
   onRefresh,
   refreshing,
+  bottomSpacing,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -146,6 +148,7 @@ export const WeekResourcesCalendar = ({
           renderResourceNameLabel={renderResourceNameLabel}
           onRefresh={onRefresh}
           refreshing={refreshing}
+          bottomSpacing={bottomSpacing}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -42,6 +42,8 @@ type WeekResourcesCalendarProps = {
   cellContainerStyle?: (resource: CalendarResource, date: Date) => ViewStyle;
   renderDateLabel?: (date: Date) => React.JSX.Element;
   renderResourceNameLabel?: (resource: CalendarResource) => React.JSX.Element;
+  onRefresh?: () => void;
+  refreshing?: boolean;
 };
 
 function getWeekStart(date: Date, weekStartsOn: WeekStartsOn): dayjs.Dayjs {
@@ -78,6 +80,8 @@ export const WeekResourcesCalendar = ({
   cellContainerStyle,
   renderDateLabel,
   renderResourceNameLabel,
+  onRefresh,
+  refreshing,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
   const { width } = useWindowDimensions();
@@ -140,6 +144,8 @@ export const WeekResourcesCalendar = ({
           cellContainerStyle={cellContainerStyle}
           renderDateLabel={renderDateLabel}
           renderResourceNameLabel={renderResourceNameLabel}
+          onRefresh={onRefresh}
+          refreshing={refreshing}
         />
       )}
       onMomentumScrollEnd={(e) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,3 +9,5 @@ export type {
   CalendarEvent as ResourcesCalendarEvent,
   CalendarResource,
 } from './types/resources-calendar';
+
+export { WeekResourcesCalendar } from './calendar/week-resources-calendar/WeekResourcesCalendar';


### PR DESCRIPTION
## Summary

- Add `WeekResourcesCalendar`, a new horizontal week-swipe calendar that displays resources as rows and the 7 days of the week as columns
- Each panel shows a fixed header row (day/date labels) with vertically scrollable resource rows beneath
- 241 panels in total (±120 weeks from `defaultDate`), matching the same FlatList paging architecture as `MonthCalendar`
- Events are rendered per resource/day cell using `ResourcesCalendarEventPosition`, supporting multi-day spans, carry-over events from the previous week, and overlap stacking
- All props from `ResourcesCalendar` ported to `WeekResourcesCalendar`: press/long-press handlers, style callbacks, render props, pull-to-refresh, fixed rows, and more
- `WeekPanel` extracted into its own file for maintainability
- Add `.zed/settings.json` to run Prettier on save

## Props

| Prop | Type | Description |
|---|---|---|
| `defaultDate` | `Date` | Initial date to display |
| `weekStartsOn` | `0 \| 1` | Week start day (0=Sun, 1=Mon) |
| `onChangeDate` | `(date: Date) => void` | Fires when the panel changes |
| `resources` | `CalendarResource[]` | Resource rows to display |
| `events` | `CalendarEvent[]` | Events to render in cells |
| `eventHeight` | `number` | Height of each event row |
| `onPressEvent` / `onLongPressEvent` / `delayLongPressEvent` | — | Event interaction |
| `onPressCell` / `onLongPressCell` / `delayLongPressCell` | — | Cell interaction |
| `prioritizeCellInteraction` | `boolean` | Overlay to prioritize cell taps over events |
| `eventTextStyle` | `(event) => TextStyle` | Custom event text style |
| `eventEllipsizeMode` | `'head' \| 'middle' \| 'tail' \| 'clip'` | Event title truncation |
| `allowFontScaling` | `boolean` | Font scaling toggle |
| `renderEventOverlay` | `(event) => ReactNode` | Badge/overlay on events |
| `dateCellContainerStyle` | `(date) => ViewStyle` | Header date cell style |
| `cellContainerStyle` | `(resource, date) => ViewStyle` | Resource day cell background style |
| `renderDateLabel` | `(date) => JSX.Element` | Custom header date cell content |
| `renderResourceNameLabel` | `(resource) => JSX.Element` | Custom resource name cell content |
| `onRefresh` / `refreshing` | — | Pull-to-refresh |
| `bottomSpacing` | `number` | Bottom padding in the scroll view |
| `fixedRowCount` | `number` | Number of resource rows pinned above the scroll area |

## Test plan

- [ ] Verify initial panel shows the week containing `defaultDate`
- [ ] Swipe left/right to confirm panel navigation and `onChangeDate` fires correctly
- [ ] Confirm events render in the correct resource row and day column
- [ ] Confirm multi-day events span correctly across columns
- [ ] Confirm carry-over events from previous week appear on Monday with no left border radius
- [ ] Confirm `fixedRowCount` rows remain visible while scrolling vertically
- [ ] Confirm pull-to-refresh works on the scrollable area
- [ ] Confirm `prioritizeCellInteraction` correctly routes taps to cell vs event

Made with [Cursor](https://cursor.com)