### PR TITLE
fix: clip overflowing events and overlay in WeekResourcesCalendar

### DIFF
--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -173,17 +173,27 @@ function DayCell({
           .startOf('day')
           .diff(startDjs.startOf('day'), 'day');
         const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(date);
+        const remainingDaysInWeek = 6 - dateIndex;
+        const isNextWeekEvent = diffDays > remainingDaysInWeek;
+        const effectiveDiffDays = isNextWeekEvent
+          ? remainingDaysInWeek
+          : diffDays;
 
         let width =
-          (diffDays + 1) * columnWidth - EVENT_GAP * 2 - CELL_BORDER_WIDTH * 2;
+          (effectiveDiffDays + 1) * columnWidth -
+          EVENT_GAP * 2 -
+          CELL_BORDER_WIDTH * 2;
         if (isPrevDateEvent) {
           width += EVENT_GAP + 1;
+        }
+        if (isNextWeekEvent) {
+          width += EVENT_GAP + CELL_BORDER_WIDTH;
         }
 
         eventPosition.push({
           resourceId: resource.id,
           startDate: startDjs.toDate(),
-          days: diffDays + 1,
+          days: effectiveDiffDays + 1,
           rowNum: rowIndex + 1,
         });
 
@@ -220,6 +230,7 @@ function DayCell({
                   }),
                 },
                 isPrevDateEvent && styles.prevDateEventInner,
+                isNextWeekEvent && styles.nextWeekEventInner,
               ]}
               activeOpacity={0.8}
               onPress={() => onPressEvent?.(event)}
@@ -520,6 +531,11 @@ const styles = StyleSheet.create({
   prevDateEventInner: {
     borderTopStartRadius: 0,
     borderBottomStartRadius: 0,
+  },
+  nextWeekEventInner: {
+    borderTopEndRadius: 0,
+    borderBottomEndRadius: 0,
+    paddingRight: 0,
   },
   event: {
     flex: 1,

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -452,6 +452,7 @@ export function WeekPanel({
 const styles = StyleSheet.create({
   panel: {
     flex: 1,
+    overflow: 'hidden',
   },
   headerRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary

- Events that extended beyond the week boundary are now capped to fit within the current week
- Next-week-spanning events are displayed without right padding and right border radius, mirroring the existing `isPrevDateEvent` style on the left side
- Added `overflow: hidden` to the `WeekPanel` root view to prevent event overlays from bleeding into adjacent week panels

## Test plan

- [ ] Verify that events spanning into the next week are clipped at the last day of the week (Sunday)
- [ ] Verify that next-week events show no right padding and no right border radius
- [ ] Verify that both ends are styled correctly alongside `isPrevDateEvent` (prev-week continuation)
- [ ] Verify that `renderEventOverlay` badges do not bleed into the neighboring panel