### PR TITLE
fix(WeekResourcesCalendar): stabilize panels and align event style with MonthCalendar

### DIFF
--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -176,7 +176,6 @@ const DayCell = memo(function DayCell({
                 isPrevDateEvent && styles.prevDateEventInner,
                 isNextWeekEvent && styles.nextWeekEventInner,
               ]}
-              activeOpacity={0.8}
               onPress={() => onPressEvent?.(event)}
               onLongPress={() => onLongPressEvent?.(event)}
               delayLongPress={delayLongPressEvent}
@@ -575,13 +574,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
     flexDirection: 'row',
     alignItems: 'center',
-    ...Platform.select({
-      android: { elevation: 2 },
-      default: {},
-    }),
+    boxShadow: '0 0 2px 0 rgba(0, 0, 0, 0.1)',
   },
   eventTitle: {
-    fontSize: 11,
+    fontSize: 12,
   },
   eventOverlayHost: {
     ...StyleSheet.absoluteFillObject,

--- a/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
+++ b/src/calendar/week-resources-calendar/WeekResourcesCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type ReactNode } from 'react';
+import React, { useState, useMemo, type ReactNode } from 'react';
 import {
   FlatList,
   useWindowDimensions,
@@ -88,31 +88,34 @@ export const WeekResourcesCalendar = ({
   fixedRowCount,
 }: WeekResourcesCalendarProps) => {
   const [_activeIndex, setActiveIndex] = useState(HALF_PANEL_LENGTH);
+  const [dateState] = useState(defaultDate);
   const { width } = useWindowDimensions();
 
-  const startOfDefaultWeek = getWeekStart(defaultDate, weekStartsOn);
+  const panels = useMemo(() => {
+    const startOfDefaultWeek = getWeekStart(dateState, weekStartsOn);
 
-  const prevPanels: string[] = Array.from(
-    { length: HALF_PANEL_LENGTH },
-    (_, i) => {
-      return startOfDefaultWeek
-        .subtract(HALF_PANEL_LENGTH - i, 'week')
-        .format('YYYY-MM-DD');
-    }
-  );
+    const prevPanels: string[] = Array.from(
+      { length: HALF_PANEL_LENGTH },
+      (_, i) => {
+        return startOfDefaultWeek
+          .subtract(HALF_PANEL_LENGTH - i, 'week')
+          .format('YYYY-MM-DD');
+      }
+    );
 
-  const nextPanels: string[] = Array.from(
-    { length: HALF_PANEL_LENGTH },
-    (_, i) => {
-      return startOfDefaultWeek.add(i + 1, 'week').format('YYYY-MM-DD');
-    }
-  );
+    const nextPanels: string[] = Array.from(
+      { length: HALF_PANEL_LENGTH },
+      (_, i) => {
+        return startOfDefaultWeek.add(i + 1, 'week').format('YYYY-MM-DD');
+      }
+    );
 
-  const panels: string[] = [
-    ...prevPanels,
-    startOfDefaultWeek.format('YYYY-MM-DD'),
-    ...nextPanels,
-  ];
+    return [
+      ...prevPanels,
+      startOfDefaultWeek.format('YYYY-MM-DD'),
+      ...nextPanels,
+    ];
+  }, [dateState, weekStartsOn]);
 
   return (
     <FlatList


### PR DESCRIPTION
## Summary

- Capture `defaultDate` in `useState` so that parent re-renders do not rebuild the panels array, aligning the implementation with `MonthCalendar`
- Wrap panels computation in `useMemo` to avoid unnecessary recalculations
- Align event appearance in `WeekPanel` with `MonthCalendar`: remove `activeOpacity` override, update font size from 11 to 12, and replace Android `elevation` with `boxShadow`

## Test plan

- [ ] Verify that swiping between weeks still works correctly after the `defaultDate` fix
- [ ] Verify that parent re-renders no longer reset the calendar to the default week
- [ ] Confirm event appearance in `WeekResourcesCalendar` visually matches `MonthCalendar`

Made with [Cursor](https://cursor.com)