### PR TITLE
fix: apply end-at-midnight boundary check to all calendars

### DIFF
--- a/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
+++ b/src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx
@@ -9,6 +9,7 @@ import {
 import { Text, TouchableOpacity, View, type ViewStyle } from 'react-native';
 import type { CalendarEvent, WeekdayNum } from '../../../types/month-calendar';
 import type MonthCalendarEventPosition from '../../../utils/month-calendar-event-position';
+import { calcDiffDays } from '../../../utils/functions';
 import { CELL_BORDER_WIDTH, EVENT_GAP } from '../../../constants/size';
 import type { TextStyle } from 'react-native';
 
@@ -121,16 +122,7 @@ export const MonthCalendarWeekRow = (props: {
           const rawStartDjs = dayjs(event.start);
           const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
           const endDjs = dayjs(event.end);
-          const isEndOnDayBoundary =
-            endDjs.hour() === 0 &&
-            endDjs.minute() === 0 &&
-            endDjs.second() === 0 &&
-            endDjs.millisecond() === 0;
-          const diffDays = Math.max(
-            0,
-            endDjs.startOf('day').diff(startDjs.startOf('day'), 'day') -
-              (isEndOnDayBoundary ? 1 : 0)
-          );
+          const diffDays = calcDiffDays(endDjs, startDjs);
 
           const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(djs);
           let width =

--- a/src/calendar/resources-calendar/ResourcesCalendar.tsx
+++ b/src/calendar/resources-calendar/ResourcesCalendar.tsx
@@ -22,7 +22,11 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { View } from 'react-native';
-import { generateDates, groupDatesByMonth } from '../../utils/functions';
+import {
+  calcDiffDays,
+  generateDates,
+  groupDatesByMonth,
+} from '../../utils/functions';
 import dayjs from 'dayjs';
 import ResourcesCalendarEventPosition from '../../utils/resources-calendar-event-position';
 import { EVENT_GAP } from '../../constants/size';
@@ -155,12 +159,8 @@ function ResourceRow({
             .sort((a, b) => {
               const aStartDjs = dateIndex === 0 ? djs : dayjs(a.start);
               const bStartDjs = dateIndex === 0 ? djs : dayjs(b.start);
-              const aDiffDays = dayjs(a.end)
-                .startOf('day')
-                .diff(aStartDjs.startOf('day'), 'day');
-              const bDiffDays = dayjs(b.end)
-                .startOf('day')
-                .diff(bStartDjs.startOf('day'), 'day');
+              const aDiffDays = calcDiffDays(dayjs(a.end), aStartDjs);
+              const bDiffDays = calcDiffDays(dayjs(b.end), bStartDjs);
               if (aDiffDays !== bDiffDays) {
                 return bDiffDays - aDiffDays;
               }
@@ -213,9 +213,7 @@ function ResourceRow({
             const rawStartDjs = dayjs(event.start);
             const startDjs = dateIndex === 0 ? djs : dayjs(event.start);
             const endDjs = dayjs(event.end);
-            const diffDays = endDjs
-              .startOf('day')
-              .diff(startDjs.startOf('day'), 'day');
+            const diffDays = calcDiffDays(endDjs, startDjs);
             const isPrevDateEvent =
               dateIndex === 0 && rawStartDjs.isBefore(djs);
 

--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -16,6 +16,7 @@ import type {
   CalendarEvent,
 } from '../../types/resources-calendar';
 import ResourcesCalendarEventPosition from '../../utils/resources-calendar-event-position';
+import { calcDiffDays } from '../../utils/functions';
 import { EVENT_GAP } from '../../constants/size';
 
 export const CELL_BORDER_WIDTH = 0.5;
@@ -120,9 +121,7 @@ const DayCell = memo(function DayCell({
         const rawStartDjs = dayjs(event.start);
         const startDjs = dateIndex === 0 ? date : rawStartDjs;
         const endDjs = dayjs(event.end);
-        const diffDays = endDjs
-          .startOf('day')
-          .diff(startDjs.startOf('day'), 'day');
+        const diffDays = calcDiffDays(endDjs, startDjs);
         const isPrevDateEvent = dateIndex === 0 && rawStartDjs.isBefore(date);
         const remainingDaysInWeek = 6 - dateIndex;
         const isNextWeekEvent = diffDays > remainingDaysInWeek;
@@ -301,12 +300,8 @@ export function WeekPanel({
           .sort((a, b) => {
             const aStartDjs = dateIndex === 0 ? date : dayjs(a.start);
             const bStartDjs = dateIndex === 0 ? date : dayjs(b.start);
-            const aDiffDays = dayjs(a.end)
-              .startOf('day')
-              .diff(aStartDjs.startOf('day'), 'day');
-            const bDiffDays = dayjs(b.end)
-              .startOf('day')
-              .diff(bStartDjs.startOf('day'), 'day');
+            const aDiffDays = calcDiffDays(dayjs(a.end), aStartDjs);
+            const bDiffDays = calcDiffDays(dayjs(b.end), bStartDjs);
             if (aDiffDays !== bDiffDays) return bDiffDays - aDiffDays;
             return dayjs(a.start).diff(dayjs(b.start));
           });
@@ -335,9 +330,7 @@ export function WeekPanel({
             const rawStartDjs = dayjs(item.start);
             const startDjs = dateIndex === 0 ? date : rawStartDjs;
             const endDjs = dayjs(item.end);
-            const diffDays = endDjs
-              .startOf('day')
-              .diff(startDjs.startOf('day'), 'day');
+            const diffDays = calcDiffDays(endDjs, startDjs);
             const remainingDaysInWeek = 6 - dateIndex;
             const isNextWeekEvent = diffDays > remainingDaysInWeek;
             const effectiveDiffDays = isNextWeekEvent

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -78,6 +78,22 @@ export function getWeekIds(args: {
   return weekIds;
 }
 
+export function calcDiffDays(
+  endDjs: dayjs.Dayjs,
+  startDjs: dayjs.Dayjs
+): number {
+  const isEndOnDayBoundary =
+    endDjs.hour() === 0 &&
+    endDjs.minute() === 0 &&
+    endDjs.second() === 0 &&
+    endDjs.millisecond() === 0;
+  return Math.max(
+    0,
+    endDjs.startOf('day').diff(startDjs.startOf('day'), 'day') -
+      (isEndOnDayBoundary ? 1 : 0)
+  );
+}
+
 export function generateDates(from: Date, to: Date): Date[] {
   const dates: Date[] = [];
   const current = new Date(from);


### PR DESCRIPTION
## Summary

- Extracted the end-at-midnight boundary logic from `MonthCalendarWeekRow` into a shared helper `calcDiffDays` in `utils/functions.ts`
- Applied `calcDiffDays` to `ResourcesCalendar` and `WeekPanel`, which previously lacked this consideration
- Refactored `MonthCalendarWeekRow` to use the same helper, removing the inline duplicate logic

## Background

When an event ends at exactly `00:00` of the next day (e.g. `2024-01-01T00:00:00` – `2024-01-02T00:00:00`), it should be treated as a 1-day event ending on January 1st, not a 2-day event spanning into January 2nd. This behaviour was already implemented in `MonthCalendarWeekRow` but was missing in the other calendar components.

## Changes

| File | Change |
|---|---|
| `src/utils/functions.ts` | Added `calcDiffDays` helper that subtracts 1 day when the end time is exactly midnight |
| `src/calendar/resources-calendar/ResourcesCalendar.tsx` | Use `calcDiffDays` for event width and sort order calculation |
| `src/calendar/week-resources-calendar/WeekPanel.tsx` | Use `calcDiffDays` in both `cellDataMap` and `DayCell` |
| `src/calendar/month-calendar/view/MonthCalendarWeekRow.tsx` | Replace inline logic with `calcDiffDays` |

## Test plan

- [ ] Verify that an event with `end` at exactly `00:00` of the next day renders as a single-day event in `ResourcesCalendar`
- [ ] Verify the same in `WeekResourcesCalendar`
- [ ] Confirm existing `MonthCalendar` behaviour is unchanged

Made with [Cursor](https://cursor.com)