### PR TITLE
fix: Remove paddingVertical from headerCell style in WeekPanel

### DIFF
--- a/src/calendar/week-resources-calendar/WeekPanel.tsx
+++ b/src/calendar/week-resources-calendar/WeekPanel.tsx
@@ -483,7 +483,6 @@ const styles = StyleSheet.create({
   headerCell: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: 6,
     borderRightWidth: CELL_BORDER_WIDTH,
     borderRightColor: BORDER_COLOR,
   },


### PR DESCRIPTION
## Summary

- Remove `paddingVertical: 6` from the `headerCell` style in `WeekPanel`

## Changes

- `src/calendar/week-resources-calendar/WeekPanel.tsx`: Removed `paddingVertical: 6` from `headerCell` in `StyleSheet.create`

Made with [Cursor](https://cursor.com)